### PR TITLE
fix: compact add-ons layout with price display

### DIFF
--- a/dashboard/src/components/AttendeeFormControl.vue
+++ b/dashboard/src/components/AttendeeFormControl.vue
@@ -72,35 +72,50 @@
 		<div v-if="availableAddOns.length > 0">
 			<hr class="my-4" />
 
-			<div v-for="addOn in availableAddOns" :key="addOn.name" class="mb-4">
-				<div class="flex flex-col gap-3">
-					<FormControl
-						type="checkbox"
-						:model-value="getAddOnSelected(addOn.name)"
-						@update:model-value="updateAddOnSelection(addOn.name, $event)"
-						:id="`add_on_${addOn.name}_${index}`"
-						:label="__(addOn.title)"
-					/>
-					<div class="text-ink-gray-5 text-sm/4" v-if="addOn.description">
-						<p>
-							{{ __(addOn.description) }}
-						</p>
-					</div>
-				</div>
-
+			<div class="space-y-1">
 				<div
-					v-if="addOn.user_selects_option && getAddOnSelected(addOn.name)"
-					class="mt-2 ml-6"
+					v-for="addOn in availableAddOns"
+					:key="addOn.name"
+					class="flex items-center justify-between gap-2 h-9"
 				>
-					<FormControl
-						:model-value="getAddOnOption(addOn.name)"
-						@update:model-value="updateAddOnOption(addOn.name, $event)"
-						type="select"
-						:options="
-							addOn.options.map((option) => ({ label: __(option), value: option }))
-						"
-						size="sm"
-					/>
+					<!-- Left: checkbox + title + info -->
+					<div class="flex items-center gap-2 min-w-0">
+						<FormControl
+							type="checkbox"
+							:model-value="getAddOnSelected(addOn.name)"
+							@update:model-value="updateAddOnSelection(addOn.name, $event)"
+							:id="`add_on_${addOn.name}_${index}`"
+						/>
+						<label
+							:for="`add_on_${addOn.name}_${index}`"
+							class="text-sm cursor-pointer truncate"
+						>
+							{{ __(addOn.title) }}
+						</label>
+						<Tooltip v-if="addOn.description" :text="__(addOn.description)">
+							<LucideInfo class="w-3.5 h-3.5 text-ink-gray-4 cursor-help shrink-0" />
+						</Tooltip>
+					</div>
+					<!-- Right: select + price -->
+					<div class="flex items-center gap-2 shrink-0">
+						<FormControl
+							v-if="addOn.user_selects_option && getAddOnSelected(addOn.name)"
+							:model-value="getAddOnOption(addOn.name)"
+							@update:model-value="updateAddOnOption(addOn.name, $event)"
+							type="select"
+							:options="
+								addOn.options.map((option) => ({
+									label: __(option),
+									value: option,
+								}))
+							"
+							size="sm"
+							class="w-24"
+						/>
+						<span class="w-16 text-right text-sm text-ink-gray-5">
+							{{ formatPriceOrFree(addOn.price, addOn.currency) }}
+						</span>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -112,6 +127,7 @@ import { Tooltip } from "frappe-ui";
 import { formatPriceOrFree } from "../utils/currency.js";
 import CustomFieldInput from "./CustomFieldInput.vue";
 import { getFieldDefaultValue } from "@/composables/useCustomFields.js";
+import LucideInfo from "~icons/lucide/info";
 
 const props = defineProps({
 	attendee: { type: Object, required: true },


### PR DESCRIPTION
Single row layout: checkbox, title, info icon, dropdown, price

**before**

<img width="401" height="779" alt="Screenshot 2026-01-04 at 11 47 49 AM" src="https://github.com/user-attachments/assets/92c183c1-9ec9-48c6-8840-dae82cc627a8" />

**after**

<img width="428" height="574" alt="Screenshot 2026-01-04 at 11 46 43 AM" src="https://github.com/user-attachments/assets/4da2d51c-4d10-4009-a814-b78a36a89db1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned add-ons layout from vertical blocks to horizontal rows, displaying checkbox, title, description tooltip, and pricing in a single row
  * Moved option selection inline with each add-on for streamlined presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->