### PR TITLE
fix: prevent duplicate add-ons per event

### DIFF
--- a/buzz/ticketing/doctype/ticket_add_on/ticket_add_on.py
+++ b/buzz/ticketing/doctype/ticket_add_on/ticket_add_on.py
@@ -1,9 +1,22 @@
 # Copyright (c) 2025, BWH Studios and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class TicketAddon(Document):
-	pass
+	def validate(self):
+		self.validate_duplicate_title()
+
+	def validate_duplicate_title(self):
+		if frappe.db.exists(
+			self.doctype,
+			{
+				"event": self.event,
+				"title": self.title,
+				"name": ["!=", self.name],
+			},
+		):
+			frappe.throw(_("Add-on <b>{0}</b> already exists for this event").format(self.title))


### PR DESCRIPTION
  Adds validation to prevent creating add-ons with same title for same event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent duplicate event add-ons. When attempting to create an add-on with the same event and title as an existing one, the system now displays a user-friendly error message. This enhancement improves data integrity and helps prevent accidental duplicate entries in your ticketing system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->