### PR TITLE
feat: link event ticket to zoom webinar registration and display join URL

### DIFF
--- a/buzz/api.py
+++ b/buzz/api.py
@@ -723,6 +723,19 @@ def get_ticket_details(ticket_id: str) -> dict:
 		can_request_cancellation(details.event.name) if details.event else {"can_request_cancellation": False}
 	)
 
+	# Get Zoom webinar join URL if applicable
+	details.zoom_join_url = None
+	if hasattr(ticket_doc, "zoom_webinar_registration") and ticket_doc.zoom_webinar_registration:
+		zoom_registration = frappe.db.get_value(
+			"Zoom Webinar Registration",
+			ticket_doc.zoom_webinar_registration,
+			["join_url", "webinar"],
+			as_dict=True,
+		)
+		if zoom_registration:
+			details.zoom_join_url = zoom_registration.join_url
+			details.zoom_webinar = zoom_registration.webinar
+
 	return details
 
 

--- a/buzz/install.py
+++ b/buzz/install.py
@@ -35,6 +35,16 @@ ZOOM_INTEGRATION_CUSTOM_FIELDS = {
 			"insert_after": "zoom_integration_section",
 		},
 	],
+	"Event Ticket": [
+		{
+			"fieldname": "zoom_webinar_registration",
+			"label": "Zoom Webinar Registration",
+			"fieldtype": "Link",
+			"options": "Zoom Webinar Registration",
+			"insert_after": "coupon_used",
+			"read_only": 1,
+		},
+	],
 }
 
 

--- a/buzz/ticketing/doctype/event_ticket/event_ticket.py
+++ b/buzz/ticketing/doctype/event_ticket/event_ticket.py
@@ -65,6 +65,8 @@ class EventTicket(Document):
 
 			try:
 				registration.submit()
+				# Store the registration reference on the ticket
+				self.db_set("zoom_webinar_registration", registration.name)
 			except Exception:
 				frappe.log_error("Failed to create registration on Zoom")
 

--- a/dashboard/src/pages/TicketDetails.vue
+++ b/dashboard/src/pages/TicketDetails.vue
@@ -216,6 +216,31 @@
 				</div>
 			</div>
 
+			<!-- Zoom Webinar Access (only shown if webinar is linked) -->
+			<div
+				v-if="ticketDetails.data.zoom_join_url"
+				class="bg-surface-cards border border-outline-gray-1 rounded-lg p-6"
+			>
+				<h3 class="text-ink-gray-8 font-semibold text-lg mb-4">
+					{{ __("Webinar Access") }}
+				</h3>
+
+				<div class="space-y-3">
+					<p class="text-sm text-ink-gray-6">
+						{{ __("Click the button below to join the webinar on Zoom.") }}
+					</p>
+					<a
+						:href="ticketDetails.data.zoom_join_url"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-2 px-4 py-2 bg-ink-blue-3 text-surface-white rounded-lg hover:bg-ink-blue-4 transition-colors"
+					>
+						<span>{{ __("Join Zoom Webinar") }}</span>
+						<LucideExternalLink class="w-4 h-4" />
+					</a>
+				</div>
+			</div>
+
 			<!-- Booking Information (only shown if user owns the booking) -->
 			<div
 				v-if="ticketDetails.data.booking"
@@ -314,6 +339,7 @@ import LucideDownload from "~icons/lucide/download";
 import LucideUserPlus from "~icons/lucide/user-plus";
 import LucideEdit from "~icons/lucide/edit";
 import LucideTriangleAlert from "~icons/lucide/triangle-alert";
+import LucideExternalLink from "~icons/lucide/external-link";
 import BackButton from "../components/common/BackButton.vue";
 
 const props = defineProps({


### PR DESCRIPTION
## Summary
- Add `zoom_webinar_registration` custom field on Event Ticket to link tickets to their Zoom registrations
- Store registration reference when creating Zoom registration on ticket submit
- Return `zoom_join_url` in `get_ticket_details` API
- Display "Webinar Access" section with join button in ticket details frontend

## Test plan
- [ ] Run `bench migrate` to create the custom field
- [ ] Create a Buzz Event with a linked Zoom Webinar (category: Webinars)
- [ ] Create a booking and submit the ticket
- [ ] Verify Event Ticket has `zoom_webinar_registration` field populated
- [ ] View ticket in frontend dashboard and verify "Webinar Access" section appears
- [ ] Click join URL to verify it opens Zoom correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Zoom webinar access directly into ticket details page
  * Displays Zoom webinar join links for event tickets with associated webinar registrations
  * Added "Webinar Access" section in Ticket Details with convenient external link to join scheduled webinars
  * Enhanced ticket registration flow to capture and link Zoom webinar details

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->