### PR TITLE
feat(event): add meta image field to website tab

### DIFF
--- a/buzz/events/doctype/buzz_event/buzz_event.json
+++ b/buzz/events/doctype/buzz_event/buzz_event.json
@@ -29,6 +29,7 @@
   "website_tab",
   "is_published",
   "route",
+  "meta_image",
   "default_ticket_type",
   "column_break_ndtl",
   "external_registration_page",
@@ -183,6 +184,11 @@
    "fieldtype": "Data",
    "label": "Route",
    "unique": 1
+  },
+  {
+   "fieldname": "meta_image",
+   "fieldtype": "Attach Image",
+   "label": "Meta Image"
   },
   {
    "default": "0",


### PR DESCRIPTION
## Summary
- Add `meta_image` field (Attach Image type) to the Website tab of Buzz Event doctype
- Enables setting Open Graph/social media preview images for events

## Test plan
- [ ] Verify the Meta Image field appears in the Website tab of Buzz Event
- [ ] Upload an image and confirm it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to attach a meta image to Buzz Events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->