### PR TITLE
fix: remove unconditional reqd flag from default_sponsor_deck_reply_to

### DIFF
--- a/buzz/events/doctype/buzz_settings/buzz_settings.json
+++ b/buzz/events/doctype/buzz_settings/buzz_settings.json
@@ -122,8 +122,7 @@
    "in_list_view": 1,
    "label": "Default Reply To",
    "mandatory_depends_on": "eval:doc.auto_send_pitch_deck",
-   "options": "Email",
-   "reqd": 1
+   "options": "Email"
   },
   {
    "fieldname": "column_break_sponsor",


### PR DESCRIPTION
Fixes test failures in `TestSponsorshipEnquiryEmail` and `TestEventTicketEmail`.

The issue was that the `default_sponsor_deck_reply_to` field had both `"reqd": 1` and `"mandatory_depends_on": "eval:doc.auto_send_pitch_deck"`. The unconditional `reqd` flag was causing validation errors in tests where `auto_send_pitch_deck` was disabled but the field was set to `None`.

Removed the `reqd` flag so the field is only mandatory when `auto_send_pitch_deck` is enabled, as intended.

Fixes #126

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the "Default Reply To" field in settings optional, allowing users to leave it blank if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->