### PR TITLE
fix: show correct error message in cancellation dialog

### DIFF
--- a/dashboard/src/components/CancellationRequestDialog.vue
+++ b/dashboard/src/components/CancellationRequestDialog.vue
@@ -297,7 +297,7 @@ const createCancellationRequest = createResource({
 	onError: (error) => {
 		submitting.value = false;
 		toast.error(
-			data.message || __("Failed to submit cancellation request. Please try again.")
+			error?.messages?.[0] || __("Failed to submit cancellation request. Please try again.")
 		);
 	},
 });


### PR DESCRIPTION
**Problem**
  Used wrong variable `data.message` - `data` doesn't exist here, so errors showed nothing.

**Fix**
  Changed to `error?.messages?.[0]` - same pattern as BookingForm.vue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message handling in cancellation request submissions to ensure accurate error messages are displayed when requests fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->