### PR TITLE
fix: prevent booking after event start date

### DIFF
--- a/buzz/api.py
+++ b/buzz/api.py
@@ -120,7 +120,7 @@ def can_request_cancellation(event_id: str | int) -> dict:
 def get_event_booking_data(event_route: str) -> dict:
 	data = frappe._dict()
 	event_doc = frappe.get_cached_doc("Buzz Event", {"route": event_route})
-
+	data.booking_allowed = event_doc.is_booking_open
 	# Ticket Types
 	available_ticket_types = []
 	published_ticket_types = frappe.db.get_all(

--- a/buzz/events/doctype/buzz_event/buzz_event.json
+++ b/buzz/events/doctype/buzz_event/buzz_event.json
@@ -21,6 +21,7 @@
   "column_break_cjby",
   "end_date",
   "end_time",
+  "booking_closes_on",
   "section_break_zukm",
   "short_description",
   "about",
@@ -391,6 +392,11 @@
    "fieldname": "card_image",
    "fieldtype": "Attach Image",
    "label": "Card Image"
+  },
+  {
+   "fieldname": "booking_closes_on",
+   "fieldtype": "Date",
+   "label": "Booking Closes On"
   }
  ],
  "grid_page_length": 50,
@@ -463,7 +469,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-01-14 11:13:04.386770",
+ "modified": "2026-01-21 20:36:44.002422",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Buzz Event",

--- a/buzz/events/doctype/buzz_settings/buzz_settings.json
+++ b/buzz/events/doctype/buzz_settings/buzz_settings.json
@@ -13,6 +13,8 @@
   "allow_add_ons_change_before_event_start_days",
   "column_break_hagy",
   "allow_ticket_cancellation_request_before_event_start_days",
+  "column_break_hyfc",
+  "allow_booking_before_event_start_days",
   "communications_tab",
   "ticketing_emails_section",
   "default_ticket_email_template",
@@ -142,13 +144,25 @@
    "fieldname": "custom_fields_go_after_this",
    "fieldtype": "HTML",
    "label": "Custom Fields Go After This"
+  },
+  {
+   "fieldname": "column_break_hyfc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Stop accepting bookings X days before event starts. Set to 0 to allow booking until event start date. Can be overridden per event.",
+   "fieldname": "allow_booking_before_event_start_days",
+   "fieldtype": "Int",
+   "label": "Allow Booking Before Event Start (Days)",
+   "non_negative": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-13 22:34:24.493305",
+ "modified": "2026-01-21 21:02:08.339821",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Buzz Settings",

--- a/buzz/events/doctype/buzz_settings/buzz_settings.py
+++ b/buzz/events/doctype/buzz_settings/buzz_settings.py
@@ -16,12 +16,13 @@ class BuzzSettings(Document):
 		from frappe.types import DF
 
 		allow_add_ons_change_before_event_start_days: DF.Int
+		allow_booking_before_event_start_days: DF.Int
 		allow_ticket_cancellation_request_before_event_start_days: DF.Int
 		allow_transfer_ticket_before_event_start_days: DF.Int
 		auto_send_pitch_deck: DF.Check
 		default_sponsor_deck_cc: DF.SmallText | None
 		default_sponsor_deck_email_template: DF.Link | None
-		default_sponsor_deck_reply_to: DF.Data
+		default_sponsor_deck_reply_to: DF.Data | None
 		default_ticket_email_template: DF.Link | None
 		support_email: DF.Data | None
 	# end: auto-generated types

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -40,6 +40,7 @@ class EventBooking(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_booking_open()
 		self.validate_ticket_availability()
 		self.fetch_amounts_from_ticket_types()
 		self.set_currency()
@@ -288,3 +289,9 @@ class EventBooking(Document):
 				frappe.throw(_("No attendees with eligible ticket type for this coupon"))
 
 			self.total_amount = self.net_amount - self.discount_amount
+
+	def validate_booking_open(self):
+		"""Check if booking is open for this event."""
+		event = frappe.get_cached_doc("Buzz Event", self.event)
+		if not event.is_booking_open:
+			frappe.throw(frappe._("Bookings are closed for {0}").format(event.title))

--- a/dashboard/src/pages/BookTickets.vue
+++ b/dashboard/src/pages/BookTickets.vue
@@ -3,7 +3,21 @@
 		<div class="w-8">
 			<Spinner v-if="eventBookingResource.loading" />
 		</div>
-		<div>
+		<!-- Booking closed message -->
+		<div
+			v-if="!eventBookingResource.loading && !eventBookingData.bookingAllowed"
+			class="flex flex-col items-center justify-center py-16"
+		>
+			<LucideCalendarX2 class="w-16 h-16 text-gray-400 mb-4" />
+			<h2 class="text-xl font-semibold text-gray-700 mb-2">
+				{{ __("Bookings Closed") }}
+			</h2>
+			<p class="text-gray-500 text-center">
+				{{ __("Bookings are no longer available for this event.") }}
+			</p>
+		</div>
+		<!-- Booking form -->
+		<div v-else>
 			<BookingForm
 				v-if="eventBookingData.availableAddOns && eventBookingData.availableTicketTypes"
 				:availableAddOns="eventBookingData.availableAddOns"
@@ -22,6 +36,7 @@
 import { reactive } from "vue";
 import BookingForm from "../components/BookingForm.vue";
 import { Spinner, createResource } from "frappe-ui";
+import LucideCalendarX2 from "~icons/lucide/calendar-x-2";
 
 const eventBookingData = reactive({
 	availableAddOns: null,
@@ -30,6 +45,7 @@ const eventBookingData = reactive({
 	eventDetails: null,
 	customFields: null,
 	paymentGateways: [],
+	bookingAllowed: true,
 });
 
 const props = defineProps({
@@ -56,6 +72,7 @@ const eventBookingResource = createResource({
 		eventBookingData.eventDetails = data.event_details || {};
 		eventBookingData.customFields = data.custom_fields || [];
 		eventBookingData.paymentGateways = data.payment_gateways || [];
+		eventBookingData.bookingAllowed = data.booking_allowed;
 	},
 	onError: (error) => {
 		if (error.message.includes("DoesNotExistError")) {


### PR DESCRIPTION
Stops users from booking tickets after event has started.                                           
                                                                                                      
**Two options for organizers**                                                                       
  1. **Global** - Stop booking X days before event (set in Buzz Settings)                             
  2. **Per event** - Pick a specific date to stop booking (set in each event)                         
                                                                                                      
  If both are set, the per-event date is used.

                                                        
  Works for max cases: close booking on start date, X days before start, or for multi-day events - any
   day between start and end.                                                

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event organizers can now set a "Booking Closes On" date to control when ticket bookings close for individual events.
  * Added global setting to configure default booking availability (days before event start).
  * Booking page displays "Bookings Closed" message and blocks form submissions after the deadline.
  * Server-side validation prevents ticket bookings when bookings are no longer open.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->