### PR TITLE
fix: prevent crash when duplicating Buzz Event

### DIFF
--- a/buzz/events/doctype/buzz_event/buzz_event.json
+++ b/buzz/events/doctype/buzz_event/buzz_event.json
@@ -198,6 +198,7 @@
    "fieldname": "route",
    "fieldtype": "Data",
    "label": "Route",
+   "no_copy": 1,
    "unique": 1
   },
   {
@@ -531,7 +532,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2026-02-02 12:39:20.030745",
+ "modified": "2026-02-11 19:31:31.774522",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Buzz Event",

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.naming import append_number_if_name_exists
 from frappe.utils.data import time_diff_in_seconds
 
 from buzz.utils import only_if_app_installed
@@ -59,6 +60,7 @@ class BuzzEvent(Document):
 		sponsor_deck_reply_to: DF.Data | None
 		start_date: DF.Date
 		start_time: DF.Time
+		tax_inclusive: DF.Check
 		tax_label: DF.Data | None
 		tax_percentage: DF.Percent
 		ticket_email_template: DF.Link | None
@@ -126,7 +128,8 @@ class BuzzEvent(Document):
 
 	def validate_route(self):
 		if self.is_published and not self.route:
-			self.route = frappe.website.utils.cleanup_page_name(self.title).replace("_", "-")
+			route = frappe.website.utils.cleanup_page_name(self.title).replace("_", "-")
+			self.route = append_number_if_name_exists("Buzz Event", route, fieldname="route")
 
 	def validate_guest_verification_config(self):
 		"""Ensure email/SMS is configured when OTP verification is enabled."""


### PR DESCRIPTION
**Summary**
 - Duplicating a published Buzz Event crashed with `UniqueValidationError` because the unique `route` field
 was copied as-is
 - Events with the same title also crashed on save since they generated identical routes

**Changes**
 - Added `no_copy: 1` to the `route` field so duplicates start with a blank route
 - Used `append_number_if_name_exists` to auto-add `-1`, `-2` etc. when a route already exists