### PR TITLE
fix: schedule time comparison and migration patch resilience

### DIFF
--- a/buzz/patches/migrate_offline_payment_to_methods.py
+++ b/buzz/patches/migrate_offline_payment_to_methods.py
@@ -4,6 +4,10 @@ import frappe
 def execute():
 	frappe.reload_doc("events", "doctype", "offline_payment_method")
 
+	# Skip if the old columns don't exist (fresh install or already migrated)
+	if not frappe.db.has_column("Buzz Event", "enable_offline_payments"):
+		return
+
 	events_with_offline = frappe.get_all(
 		"Buzz Event",
 		filters={"enable_offline_payments": 1},


### PR DESCRIPTION
## Summary
- Use `get_time()` for schedule time comparisons in `BuzzEvent.validate_schedule()` to fix string ordering bug (e.g. `"9:00"` > `"11:00"` as strings)
- Skip offline payment migration patch when old columns don't exist on the database (fresh installs or already-migrated sites)

## Test plan
- [x] Added unit tests for schedule time validation (before/after event boundaries)
- [ ] Verify `bench migrate` succeeds on a fresh site without old offline payment columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)