### PR TITLE
fix: revalidate stored ticket types on page load

### DIFF
--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -835,13 +835,19 @@ watch(
 );
 
 // Auto-select ticket type based on event's default or if there's only one available
+// Also revalidate stored ticket types (from localStorage) against currently available ones
 watch(
 	() => props.availableTicketTypes,
 	(newTicketTypes) => {
 		if (newTicketTypes && newTicketTypes.length > 0) {
 			const defaultTicketType = getDefaultTicketType();
+			const availableIds = new Set(newTicketTypes.map((tt) => String(tt.name)));
 			for (const attendee of attendees.value) {
-				if (!attendee.ticket_type || attendee.ticket_type === "") {
+				if (
+					!attendee.ticket_type ||
+					attendee.ticket_type === "" ||
+					!availableIds.has(String(attendee.ticket_type))
+				) {
 					attendee.ticket_type = defaultTicketType;
 				}
 			}


### PR DESCRIPTION
## Summary
- Fixes stale ticket type IDs from localStorage causing "tickets no longer available" errors even when valid ticket types are selected
- When `availableTicketTypes` loads, the watcher now checks that each attendee's stored `ticket_type` still exists in the available list — if not, it resets to the default
- Previously the watcher only checked for empty values, so a ticket type that was unpublished after the user's last visit would silently persist and fail on submit

## Test plan
- [ ] Open booking page, select a ticket type, partially fill form, leave the page
- [ ] Unpublish that ticket type from the backend
- [ ] Revisit the booking page — attendees should now have the default available ticket type, not the stale one
- [ ] Submit booking successfully without "tickets no longer available" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)