### PR TITLE
fix: banner height auto in registrations page

### DIFF
--- a/dashboard/src/components/EventDetailsHeader.vue
+++ b/dashboard/src/components/EventDetailsHeader.vue
@@ -9,7 +9,7 @@
 			<img
 				:src="eventDetails.banner_image"
 				:alt="eventDetails.title"
-				class="w-full h-full object-cover contrast-100 brightness-100"
+				class="w-full h-auto object-cover contrast-100 brightness-100"
 			/>
 		</div>
 


### PR DESCRIPTION
<img width="1470" height="881" alt="image" src="https://github.com/user-attachments/assets/3d9ea894-47db-47a6-865a-2576dec05182" />
