### PR TITLE
fix: logo if user is guest

### DIFF
--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -983,7 +983,10 @@ def create_cancellation_request(booking_id: str, ticket_ids: list | None = None)
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_user_info() -> dict:
 	if frappe.session.user == "Guest":
-		return {"is_logged_in": False}
+		return {
+			"is_logged_in": False,
+			"brand_image": frappe.db.get_single_value("Website Settings", "banner_image"),
+		}
 
 	user = frappe.get_cached_doc("User", frappe.session.user)
 

--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -985,7 +985,7 @@ def get_user_info() -> dict:
 	if frappe.session.user == "Guest":
 		return {
 			"is_logged_in": False,
-			"brand_image": frappe.db.get_single_value("Website Settings", "banner_image"),
+			"brand_image": frappe.get_cached_value("Website Settings", "banner_image"),
 		}
 
 	user = frappe.get_cached_doc("User", frappe.session.user)


### PR DESCRIPTION
In registration page if user is not logged in it shows buzz logo by default if app logo is not set. This pr gets app logo from website settings if not available then fallbacks to buzz logo

<img width="1441" height="639" alt="image" src="https://github.com/user-attachments/assets/43af1c99-d286-4de4-94ff-cee85324faac" />
