### PR TITLE
feat: add company and banner fields to event proposal form

### DIFF
--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -14,8 +14,6 @@ EVENT_PROPOSAL_EXCLUDE_FIELDS = DEFAULT_FIELDS | {
 	"naming_series",
 	"amended_from",
 	"host",
-	"host_company",
-	"host_company_logo",
 	"additional_notes",
 	"status",
 	"submitted_by",

--- a/buzz/proposals/doctype/event_proposal/event_proposal.json
+++ b/buzz/proposals/doctype/event_proposal/event_proposal.json
@@ -26,8 +26,14 @@
   "host",
   "section_break_xzvg",
   "host_company",
-  "additional_notes",
+  "column_break_kjra",
   "host_company_logo",
+  "column_break_rryk",
+  "event_banner",
+  "section_break_wtpz",
+  "about_the_company",
+  "section_break_ehhk",
+  "additional_notes",
   "section_break_kray",
   "amended_from"
  ],
@@ -69,7 +75,7 @@
   {
    "fieldname": "host_company",
    "fieldtype": "Data",
-   "label": "Host Company"
+   "label": "Company Name"
   },
   {
    "fieldname": "additional_notes",
@@ -88,9 +94,10 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "This logo will be used across the site",
    "fieldname": "host_company_logo",
    "fieldtype": "Attach Image",
-   "label": "Host Company Logo"
+   "label": "Company Logo"
   },
   {
    "fieldname": "section_break_psfj",
@@ -124,13 +131,13 @@
   {
    "fieldname": "about",
    "fieldtype": "Text Editor",
-   "label": "About the event",
+   "label": "About the Event",
    "reqd": 1
   },
   {
    "fieldname": "short_description",
    "fieldtype": "Small Text",
-   "label": "Short Description"
+   "label": "Short Description of Event"
   },
   {
    "default": "Online",
@@ -167,13 +174,39 @@
   {
    "fieldname": "section_break_xzvg",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_kjra",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "event_banner",
+   "fieldtype": "Attach Image",
+   "label": "Event Banner"
+  },
+  {
+   "fieldname": "section_break_ehhk",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_wtpz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "about_the_company",
+   "fieldtype": "Small Text",
+   "label": "About the Company"
+  },
+  {
+   "fieldname": "column_break_rryk",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-11 07:52:43.388259",
+ "modified": "2026-06-20 17:30:09.585422",
  "modified_by": "Administrator",
  "module": "Proposals",
  "name": "Event Proposal",

--- a/buzz/proposals/doctype/event_proposal/event_proposal.py
+++ b/buzz/proposals/doctype/event_proposal/event_proposal.py
@@ -18,11 +18,13 @@ class EventProposal(Document):
 		from frappe.types import DF
 
 		about: DF.TextEditor
+		about_the_company: DF.SmallText | None
 		additional_notes: DF.SmallText | None
 		amended_from: DF.Link | None
 		category: DF.Link
 		end_date: DF.Date | None
 		end_time: DF.Time | None
+		event_banner: DF.AttachImage | None
 		free_webinar: DF.Check
 		host: DF.Link | None
 		host_company: DF.Data | None


### PR DESCRIPTION
Allow users to add Company Details and Event Banner for Event Proposal

<img width="863" height="809" alt="Screenshot 2026-06-20 at 6 22 32 PM" src="https://github.com/user-attachments/assets/e02ed5b0-6a3d-467b-aa40-f44220403576" />
