### PR TITLE
fix: show account proposal & sponsorship tabs only when user has activity

### DIFF
--- a/dashboard/src/pages/Account.vue
+++ b/dashboard/src/pages/Account.vue
@@ -27,7 +27,8 @@
 
 <script setup>
 import ProfileView from "@/components/ProfileView.vue";
-import { Tabs } from "frappe-ui";
+import { session } from "@/data/session";
+import { Tabs, createResource, useList } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import LucideCalendarDays from "~icons/lucide/calendar-days";
@@ -38,33 +39,62 @@ import LucideTicket from "~icons/lucide/ticket";
 const route = useRoute();
 const router = useRouter();
 
-const tabs = [
-	{
-		label: __("My Bookings"),
-		route: "/account/bookings",
-		icon: LucideCalendarDays,
-	},
-	{ label: __("My Tickets"), route: "/account/tickets", icon: LucideTicket },
-	{
-		label: __("Talk Proposals"),
-		route: "/account/proposals",
-		icon: LucideMegaphone,
-	},
-	{
-		label: __("Sponsorships"),
-		route: "/account/sponsorships",
-		icon: LucideCircleDollarSign,
-	},
-];
+// Opt-in tabs (Proposals, Sponsorships) appear only when the user has activity there.
+// Own cacheKeys (not the list pages') so this lighter field/transform shape can't clobber theirs.
+const proposals = useList({
+	doctype: "Talk Proposal",
+	fields: ["name"],
+	filters: { submitted_by: session.user },
+	auto: true,
+	cacheKey: ["account-proposals-check", session.user],
+});
 
-const selectOptions = tabs.map((tab) => ({
-	label: tab.label,
-	value: tab.route,
-}));
+const sponsorships = createResource({
+	url: "buzz.api.get_user_sponsorship_inquiries",
+	auto: true,
+	cacheKey: "account-sponsorships-check",
+	onError: console.error,
+});
+
+const tabs = computed(() => {
+	const accountTabs = [
+		{
+			label: __("My Bookings"),
+			route: "/account/bookings",
+			icon: LucideCalendarDays,
+		},
+		{ label: __("My Tickets"), route: "/account/tickets", icon: LucideTicket },
+	];
+
+	if (proposals.data?.length) {
+		accountTabs.push({
+			label: __("Talk Proposals"),
+			route: "/account/proposals",
+			icon: LucideMegaphone,
+		});
+	}
+
+	if (sponsorships.data?.length) {
+		accountTabs.push({
+			label: __("Sponsorships"),
+			route: "/account/sponsorships",
+			icon: LucideCircleDollarSign,
+		});
+	}
+
+	return accountTabs;
+});
+
+const selectOptions = computed(() =>
+	tabs.value.map((tab) => ({
+		label: tab.label,
+		value: tab.route,
+	}))
+);
 
 const currentTabRoute = computed(() => {
-	const tab = tabs.find((tab) => route.path.startsWith(tab.route));
-	return tab ? tab.route : tabs[0].route;
+	const tab = tabs.value.find((tab) => route.path.startsWith(tab.route));
+	return tab ? tab.route : tabs.value[0].route;
 });
 
 function onSelectChange(value) {
@@ -74,17 +104,30 @@ function onSelectChange(value) {
 // Find the tab index based on current route path
 const getTabIndexFromRoute = () => {
 	const currentPath = route.path;
-	const index = tabs.findIndex((tab) => currentPath.startsWith(tab.route));
+	const index = tabs.value.findIndex((tab) => currentPath.startsWith(tab.route));
 	return index >= 0 ? index : 0;
 };
 
 const tabIndex = ref(getTabIndexFromRoute());
 
-// Watch for route changes and update tab index
+// Keep URL, active tab and view in sync. If the route points at an opt-in tab the user
+// no longer has (e.g. a stale deep link), send them to the first tab once data has settled.
 watch(
-	() => route.path,
+	[
+		() => route.path,
+		() => tabs.value.length,
+		() => proposals.loading,
+		() => sponsorships.loading,
+	],
 	() => {
+		const onKnownTab = tabs.value.some((tab) => route.path.startsWith(tab.route));
+		const settled = !proposals.loading && !sponsorships.loading;
+		if (!onKnownTab && settled && route.path.startsWith("/account/")) {
+			router.replace(tabs.value[0].route);
+			return;
+		}
 		tabIndex.value = getTabIndexFromRoute();
-	}
+	},
+	{ immediate: true }
 );
 </script>

--- a/dashboard/src/pages/Account.vue
+++ b/dashboard/src/pages/Account.vue
@@ -39,8 +39,6 @@ import LucideTicket from "~icons/lucide/ticket";
 const route = useRoute();
 const router = useRouter();
 
-// Opt-in tabs (Proposals, Sponsorships) appear only when the user has activity there.
-// Own cacheKeys (not the list pages') so this lighter field/transform shape can't clobber theirs.
 const proposals = useList({
 	doctype: "Talk Proposal",
 	fields: ["name"],
@@ -110,8 +108,6 @@ const getTabIndexFromRoute = () => {
 
 const tabIndex = ref(getTabIndexFromRoute());
 
-// Keep URL, active tab and view in sync. If the route points at an opt-in tab the user
-// no longer has (e.g. a stale deep link), send them to the first tab once data has settled.
 watch(
 	[
 		() => route.path,


### PR DESCRIPTION
Only show Sponsorship Tab and Talk Proposal if you have any entry for it
Closes #225.

