### PR TITLE
fix: use corner x icon to remove uploaded image

### DIFF
--- a/dashboard/src/components/CustomFieldInput.vue
+++ b/dashboard/src/components/CustomFieldInput.vue
@@ -108,14 +108,13 @@
 		<div v-if="modelValue" class="relative inline-block">
 			<img :src="modelValue" class="h-16 w-16 rounded object-cover border" />
 			<Button
-				variant="solid"
-				theme="gray"
+				variant="ghost"
 				:title="__('Remove image')"
 				:aria-label="__('Remove image')"
-				class="absolute -top-2 -right-2 !rounded-full !p-1 !min-w-0"
+				class="absolute top-1 right-1 !min-w-0 !p-0.5 rounded-full bg-black/50 hover:bg-black/70"
 				@click="$emit('update:modelValue', '')"
 			>
-				<LucideX class="w-3 h-3" />
+				<LucideX class="w-3.5 h-3.5 text-red-500" />
 			</Button>
 		</div>
 		<FileUploader

--- a/dashboard/src/components/CustomFieldInput.vue
+++ b/dashboard/src/components/CustomFieldInput.vue
@@ -112,7 +112,7 @@
 				theme="gray"
 				:label="__('Remove image')"
 				:title="__('Remove image')"
-				class="absolute -right-1.5 -top-1.5 !min-w-0 !rounded-full !p-1"
+				class="absolute -right-1.5 -top-1.5 !h-5 !w-5 !min-w-0 !rounded-full !p-0"
 				@click="$emit('update:modelValue', '')"
 			>
 				<LucideX class="h-3 w-3" />

--- a/dashboard/src/components/CustomFieldInput.vue
+++ b/dashboard/src/components/CustomFieldInput.vue
@@ -105,10 +105,17 @@
 			{{ __(field.label) }}
 			<span v-if="field.mandatory" class="text-ink-red-4">*</span>
 		</label>
-		<div v-if="modelValue" class="flex items-center gap-2">
+		<div v-if="modelValue" class="relative inline-block">
 			<img :src="modelValue" class="h-16 w-16 rounded object-cover border" />
-			<Button variant="ghost" size="sm" @click="$emit('update:modelValue', '')">
-				{{ __("Remove") }}
+			<Button
+				variant="solid"
+				theme="gray"
+				:title="__('Remove image')"
+				:aria-label="__('Remove image')"
+				class="absolute -top-2 -right-2 !rounded-full !p-1 !min-w-0"
+				@click="$emit('update:modelValue', '')"
+			>
+				<LucideX class="w-3 h-3" />
 			</Button>
 		</div>
 		<FileUploader
@@ -183,6 +190,7 @@ import {
 	Textarea,
 } from "frappe-ui";
 import { computed } from "vue";
+import LucideX from "~icons/lucide/x";
 
 const props = defineProps({
 	field: {

--- a/dashboard/src/components/CustomFieldInput.vue
+++ b/dashboard/src/components/CustomFieldInput.vue
@@ -108,13 +108,14 @@
 		<div v-if="modelValue" class="relative inline-block">
 			<img :src="modelValue" class="h-16 w-16 rounded object-cover border" />
 			<Button
-				variant="ghost"
+				variant="subtle"
+				theme="gray"
+				:label="__('Remove image')"
 				:title="__('Remove image')"
-				:aria-label="__('Remove image')"
-				class="absolute top-1 right-1 !min-w-0 !p-0.5 rounded-full bg-black/50 hover:bg-black/70"
+				class="absolute -right-1.5 -top-1.5 !min-w-0 !rounded-full !p-1"
 				@click="$emit('update:modelValue', '')"
 			>
-				<LucideX class="w-3.5 h-3.5 text-red-500" />
+				<LucideX class="h-3 w-3" />
 			</Button>
 		</div>
 		<FileUploader


### PR DESCRIPTION
Replace the "Remove" button beside uploaded images with an x icon on the top-right corner.

Closes #222

### Demo

#### Light Mode

<img width="113" height="122" alt="Screenshot 2026-06-21 at 7 31 57 AM" src="https://github.com/user-attachments/assets/7cad630c-f5d2-4a6c-a47b-18012dbb6612" />


#### Dark Mode

<img width="176" height="129" alt="Screenshot 2026-06-21 at 7 31 52 AM" src="https://github.com/user-attachments/assets/a7b9eb55-301e-4013-8363-dfe82445df26" />

