### PR TITLE
fix: apply coupons without login (require login only at checkout)

### DIFF
--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -1166,10 +1166,6 @@ def has_app_permission():
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def validate_coupon(coupon_code: str, event: str, user_email: str | None = None) -> dict:
-	event_doc = frappe.get_cached_doc("Buzz Event", event)
-	if frappe.session.user == "Guest" and not event_doc.allow_guest_booking:
-		frappe.throw(_("Please log in to access this feature"), frappe.AuthenticationError)
-
 	if not frappe.db.exists("Buzz Coupon Code", coupon_code):
 		return {"valid": False, "error": _("Invalid coupon code")}
 

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -841,7 +841,9 @@ onMounted(async () => {
 	const initialCoupon = appliedCouponQuery.value;
 	if (typeof initialCoupon === "string" && initialCoupon.trim() && !couponApplied.value) {
 		couponCode.value = initialCoupon.trim().toUpperCase();
-		await applyCoupon();
+		if (!requiresLogin.value) {
+			await applyCoupon();
+		}
 	}
 });
 
@@ -983,6 +985,11 @@ function sendOtpForVerification() {
 
 // --- COUPON FUNCTIONS ---
 async function applyCoupon() {
+	if (requiresLogin.value) {
+		openLoginDialog();
+		return;
+	}
+
 	const normalizedCode = couponCode.value.trim().toUpperCase();
 	if (!normalizedCode) {
 		couponError.value = __("Please enter a coupon code");

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -841,9 +841,7 @@ onMounted(async () => {
 	const initialCoupon = appliedCouponQuery.value;
 	if (typeof initialCoupon === "string" && initialCoupon.trim() && !couponApplied.value) {
 		couponCode.value = initialCoupon.trim().toUpperCase();
-		if (!requiresLogin.value) {
-			await applyCoupon();
-		}
+		await applyCoupon();
 	}
 });
 
@@ -985,11 +983,6 @@ function sendOtpForVerification() {
 
 // --- COUPON FUNCTIONS ---
 async function applyCoupon() {
-	if (requiresLogin.value) {
-		openLoginDialog();
-		return;
-	}
-
 	const normalizedCode = couponCode.value.trim().toUpperCase();
 	if (!normalizedCode) {
 		couponError.value = __("Please enter a coupon code");


### PR DESCRIPTION
Let guests apply coupons without logging in — login is only required at checkout.

## Demo


https://github.com/user-attachments/assets/f3bf5433-2905-4784-9588-e67b10c9928f

