### PR TITLE
fix: add layout break support in custom forms

### DIFF
--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -190,7 +190,7 @@ def get_custom_form_data(event_route: str, form_route: str) -> dict:
 
 	auto_set = get_auto_set_fields(form_doctype)
 	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys())
-	form_fields = get_form_fields(form_doctype, exclude_fields)
+	form_fields = get_form_fields(form_doctype, exclude_fields, with_layout_breaks=True)
 
 	form_doctype_meta = frappe.get_meta(form_doctype)
 	custom_fields = []

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.json
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.json
@@ -10,10 +10,10 @@
   "column_break_esac",
   "status",
   "event",
+  "section_break_gusn",
+  "speakers",
   "section_break_yqfb",
   "description",
-  "column_break_kemm",
-  "speakers",
   "section_break_ouiw",
   "phone",
   "section_break_additional",
@@ -61,10 +61,6 @@
    "label": "Description"
   },
   {
-   "fieldname": "column_break_kemm",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "speakers",
    "fieldtype": "Table",
    "label": "Speakers",
@@ -89,6 +85,10 @@
    "fieldtype": "Table",
    "label": "Additional Fields",
    "options": "Additional Field"
+  },
+  {
+   "fieldname": "section_break_gusn",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
@@ -99,7 +99,7 @@
    "link_fieldname": "proposal"
   }
  ],
- "modified": "2026-03-23 17:28:23.254661",
+ "modified": "2026-06-21 09:15:43.483668",
  "modified_by": "Administrator",
  "module": "Proposals",
  "name": "Talk Proposal",

--- a/dashboard/components.d.ts
+++ b/dashboard/components.d.ts
@@ -26,6 +26,7 @@ declare module 'vue' {
     EventDetailsHeader: typeof import('./src/components/EventDetailsHeader.vue')['default']
     EventSelector: typeof import('./src/components/EventSelector.vue')['default']
     EventSponsorForm: typeof import('./src/components/EventSponsorForm.vue')['default']
+    FormFieldSections: typeof import('./src/components/FormFieldSections.vue')['default']
     LanguageSwitcher: typeof import('./src/components/LanguageSwitcher.vue')['default']
     LoginDialog: typeof import('./src/components/LoginDialog.vue')['default']
     LoginRequired: typeof import('./src/components/LoginRequired.vue')['default']

--- a/dashboard/src/components/BaseCustomEventForm.vue
+++ b/dashboard/src/components/BaseCustomEventForm.vue
@@ -49,51 +49,73 @@
 					{{ formData.form_title }}
 				</h1>
 
-				<div class="space-y-4">
-					<template v-for="field in formData.form_fields" :key="field.fieldname">
-						<div v-if="field.fieldtype === 'Table'" class="space-y-2">
-							<label class="text-xs text-ink-gray-5 block">
-								{{ __(field.label) }}
-							</label>
-							<div v-if="tableData[field.fieldname]?.length" class="space-y-2">
-								<div
-									v-for="(row, idx) in tableData[field.fieldname]"
-									:key="idx"
-									class="flex items-center justify-between border rounded-md px-3 py-2"
-								>
-									<span class="text-sm text-ink-gray-7">
-										{{ getTableRowSummary(row) }}
-									</span>
-									<div class="flex gap-1">
-										<Button
-											variant="ghost"
-											size="sm"
-											@click="editTableRow(field, idx)"
+				<div class="space-y-6">
+					<div
+						v-for="(section, section_index) in field_sections"
+						:key="section_index"
+						class="grid gap-4 grid-cols-1 sm:[grid-template-columns:var(--section-columns)]"
+						:style="{
+							'--section-columns': `repeat(${section.length}, minmax(0, 1fr))`,
+						}"
+					>
+						<div
+							v-for="(column, column_index) in section"
+							:key="column_index"
+							class="space-y-4"
+						>
+							<template v-for="field in column" :key="field.fieldname">
+								<div v-if="field.fieldtype === 'Table'" class="space-y-2">
+									<label class="text-xs text-ink-gray-5 block">
+										{{ __(field.label) }}
+									</label>
+									<div
+										v-if="tableData[field.fieldname]?.length"
+										class="space-y-2"
+									>
+										<div
+											v-for="(row, idx) in tableData[field.fieldname]"
+											:key="idx"
+											class="flex items-center justify-between border rounded-md px-3 py-2"
 										>
-											{{ __("Edit") }}
-										</Button>
-										<Button
-											variant="ghost"
-											size="sm"
-											@click="removeTableRow(field.fieldname, idx)"
-										>
-											{{ __("Remove") }}
-										</Button>
+											<span class="text-sm text-ink-gray-7">
+												{{ getTableRowSummary(row) }}
+											</span>
+											<div class="flex gap-1">
+												<Button
+													variant="ghost"
+													size="sm"
+													@click="editTableRow(field, idx)"
+												>
+													{{ __("Edit") }}
+												</Button>
+												<Button
+													variant="ghost"
+													size="sm"
+													@click="removeTableRow(field.fieldname, idx)"
+												>
+													{{ __("Remove") }}
+												</Button>
+											</div>
+										</div>
 									</div>
+									<Button
+										variant="outline"
+										size="sm"
+										@click="addTableRow(field)"
+									>
+										{{ __("Add {0}", [__(field.label)]) }}
+									</Button>
 								</div>
-							</div>
-							<Button variant="outline" size="sm" @click="addTableRow(field)">
-								{{ __("Add {0}", [__(field.label)]) }}
-							</Button>
-						</div>
 
-						<CustomFieldInput
-							v-else
-							:field="normalizeField(field)"
-							:model-value="formValues[field.fieldname]"
-							@update:model-value="formValues[field.fieldname] = $event"
-						/>
-					</template>
+								<CustomFieldInput
+									v-else
+									:field="normalizeField(field)"
+									:model-value="formValues[field.fieldname]"
+									@update:model-value="formValues[field.fieldname] = $event"
+								/>
+							</template>
+						</div>
+					</div>
 
 					<CustomFieldsSection
 						v-if="formData.custom_fields?.length"
@@ -196,6 +218,30 @@ const renderedSuccessMessage = computed(() => {
 	const msg = formData.value?.success_message;
 	if (!msg) return "";
 	return marked(msg);
+});
+
+const field_sections = computed(() => {
+	const fields = formData.value?.form_fields || [];
+	const sections = [];
+	let current_section = [[]];
+	for (const field of fields) {
+		if (field.fieldtype === "Section Break") {
+			if (current_section.some((col) => col.length)) {
+				sections.push(current_section);
+			}
+			current_section = [[]];
+			continue;
+		}
+		if (field.fieldtype === "Column Break") {
+			current_section.push([]);
+			continue;
+		}
+		current_section[current_section.length - 1].push(field);
+	}
+	if (current_section.some((col) => col.length)) {
+		sections.push(current_section);
+	}
+	return sections;
 });
 
 function normalizeField(field) {

--- a/dashboard/src/components/BaseCustomEventForm.vue
+++ b/dashboard/src/components/BaseCustomEventForm.vue
@@ -50,72 +50,52 @@
 				</h1>
 
 				<div class="space-y-6">
-					<div
-						v-for="(section, section_index) in field_sections"
-						:key="section_index"
-						class="grid gap-4 grid-cols-1 sm:[grid-template-columns:var(--section-columns)]"
-						:style="{
-							'--section-columns': `repeat(${section.length}, minmax(0, 1fr))`,
-						}"
-					>
-						<div
-							v-for="(column, column_index) in section"
-							:key="column_index"
-							class="space-y-4"
-						>
-							<template v-for="field in column" :key="field.fieldname">
-								<div v-if="field.fieldtype === 'Table'" class="space-y-2">
-									<label class="text-xs text-ink-gray-5 block">
-										{{ __(field.label) }}
-									</label>
+					<FormFieldSections :fields="formData.form_fields">
+						<template #field="{ field }">
+							<div v-if="field.fieldtype === 'Table'" class="space-y-2">
+								<label class="text-xs text-ink-gray-5 block">
+									{{ __(field.label) }}
+								</label>
+								<div v-if="tableData[field.fieldname]?.length" class="space-y-2">
 									<div
-										v-if="tableData[field.fieldname]?.length"
-										class="space-y-2"
+										v-for="(row, idx) in tableData[field.fieldname]"
+										:key="idx"
+										class="flex items-center justify-between gap-2 border border-outline-gray-2 rounded-md px-3 py-2"
 									>
-										<div
-											v-for="(row, idx) in tableData[field.fieldname]"
-											:key="idx"
-											class="flex items-center justify-between border rounded-md px-3 py-2"
-										>
-											<span class="text-sm text-ink-gray-7">
-												{{ getTableRowSummary(row) }}
-											</span>
-											<div class="flex gap-1">
-												<Button
-													variant="ghost"
-													size="sm"
-													@click="editTableRow(field, idx)"
-												>
-													{{ __("Edit") }}
-												</Button>
-												<Button
-													variant="ghost"
-													size="sm"
-													@click="removeTableRow(field.fieldname, idx)"
-												>
-													{{ __("Remove") }}
-												</Button>
-											</div>
+										<span class="text-sm text-ink-gray-7 min-w-0 truncate">
+											{{ getTableRowSummary(row) }}
+										</span>
+										<div class="flex gap-1 shrink-0">
+											<Button
+												variant="ghost"
+												size="sm"
+												@click="editTableRow(field, idx)"
+											>
+												{{ __("Edit") }}
+											</Button>
+											<Button
+												variant="ghost"
+												size="sm"
+												@click="removeTableRow(field.fieldname, idx)"
+											>
+												{{ __("Remove") }}
+											</Button>
 										</div>
 									</div>
-									<Button
-										variant="outline"
-										size="sm"
-										@click="addTableRow(field)"
-									>
-										{{ __("Add {0}", [__(field.label)]) }}
-									</Button>
 								</div>
+								<Button variant="outline" size="sm" @click="addTableRow(field)">
+									{{ __("Add {0}", [__(field.label)]) }}
+								</Button>
+							</div>
 
-								<CustomFieldInput
-									v-else
-									:field="normalizeField(field)"
-									:model-value="formValues[field.fieldname]"
-									@update:model-value="formValues[field.fieldname] = $event"
-								/>
-							</template>
-						</div>
-					</div>
+							<CustomFieldInput
+								v-else
+								:field="normalizeField(field)"
+								:model-value="formValues[field.fieldname]"
+								@update:model-value="formValues[field.fieldname] = $event"
+							/>
+						</template>
+					</FormFieldSections>
 
 					<CustomFieldsSection
 						v-if="formData.custom_fields?.length"
@@ -179,6 +159,7 @@
 import CustomFieldInput from "@/components/CustomFieldInput.vue";
 import CustomFieldsSection from "@/components/CustomFieldsSection.vue";
 import EventDetailsHeader from "@/components/EventDetailsHeader.vue";
+import FormFieldSections from "@/components/FormFieldSections.vue";
 import LoginRequired from "@/components/LoginRequired.vue";
 import { Button, Dialog, Spinner, createResource, toast } from "frappe-ui";
 import { marked } from "marked";
@@ -218,30 +199,6 @@ const renderedSuccessMessage = computed(() => {
 	const msg = formData.value?.success_message;
 	if (!msg) return "";
 	return marked(msg);
-});
-
-const field_sections = computed(() => {
-	const fields = formData.value?.form_fields || [];
-	const sections = [];
-	let current_section = [[]];
-	for (const field of fields) {
-		if (field.fieldtype === "Section Break") {
-			if (current_section.some((col) => col.length)) {
-				sections.push(current_section);
-			}
-			current_section = [[]];
-			continue;
-		}
-		if (field.fieldtype === "Column Break") {
-			current_section.push([]);
-			continue;
-		}
-		current_section[current_section.length - 1].push(field);
-	}
-	if (current_section.some((col) => col.length)) {
-		sections.push(current_section);
-	}
-	return sections;
 });
 
 function normalizeField(field) {

--- a/dashboard/src/components/FormFieldSections.vue
+++ b/dashboard/src/components/FormFieldSections.vue
@@ -1,0 +1,52 @@
+<template>
+	<div class="space-y-6">
+		<div
+			v-for="(section, section_index) in sections"
+			:key="section_index"
+			class="grid gap-4 grid-cols-1 sm:[grid-template-columns:var(--section-columns)]"
+			:style="{
+				'--section-columns': `repeat(${section.length}, minmax(0, 1fr))`,
+			}"
+		>
+			<div v-for="(column, column_index) in section" :key="column_index" class="space-y-4">
+				<template v-for="field in column" :key="field.fieldname">
+					<slot name="field" :field="field" />
+				</template>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	fields: {
+		type: Array,
+		default: () => [],
+	},
+});
+
+const sections = computed(() => {
+	const sections = [];
+	let current_section = [[]];
+	for (const field of props.fields) {
+		if (field.fieldtype === "Section Break") {
+			if (current_section.some((column) => column.length)) {
+				sections.push(current_section);
+			}
+			current_section = [[]];
+			continue;
+		}
+		if (field.fieldtype === "Column Break") {
+			current_section.push([]);
+			continue;
+		}
+		current_section[current_section.length - 1].push(field);
+	}
+	if (current_section.some((column) => column.length)) {
+		sections.push(current_section);
+	}
+	return sections;
+});
+</script>

--- a/dashboard/src/pages/EventProposalForm.vue
+++ b/dashboard/src/pages/EventProposalForm.vue
@@ -37,29 +37,16 @@
 					</h1>
 				</div>
 
-				<div class="p-6 space-y-6">
-					<div
-						v-for="(section, section_index) in field_sections"
-						:key="section_index"
-						class="grid gap-4"
-						:style="{
-							gridTemplateColumns: `repeat(${section.length}, minmax(0, 1fr))`,
-						}"
-					>
-						<div
-							v-for="(column, column_index) in section"
-							:key="column_index"
-							class="space-y-4"
-						>
+				<div class="p-6">
+					<FormFieldSections :fields="form_data.form_fields">
+						<template #field="{ field }">
 							<CustomFieldInput
-								v-for="field in column"
-								:key="field.fieldname"
 								:field="{ ...field, mandatory: field.reqd }"
 								:model-value="form_values[field.fieldname]"
 								@update:model-value="form_values[field.fieldname] = $event"
 							/>
-						</div>
-					</div>
+						</template>
+					</FormFieldSections>
 				</div>
 
 				<div class="px-6 pb-6">
@@ -92,6 +79,7 @@
 
 <script setup>
 import CustomFieldInput from "@/components/CustomFieldInput.vue";
+import FormFieldSections from "@/components/FormFieldSections.vue";
 import LoginRequired from "@/components/LoginRequired.vue";
 import { Button, Spinner, createResource, toast } from "frappe-ui";
 import { marked } from "marked";
@@ -109,30 +97,6 @@ const rendered_success_message = computed(() => {
 	const msg = form_data.value?.success_message;
 	if (!msg) return "";
 	return marked(msg);
-});
-
-const field_sections = computed(() => {
-	const fields = form_data.value?.form_fields || [];
-	const sections = [];
-	let current_section = [[]];
-	for (const field of fields) {
-		if (field.fieldtype === "Section Break") {
-			if (current_section.some((col) => col.length)) {
-				sections.push(current_section);
-			}
-			current_section = [[]];
-			continue;
-		}
-		if (field.fieldtype === "Column Break") {
-			current_section.push([]);
-			continue;
-		}
-		current_section[current_section.length - 1].push(field);
-	}
-	if (current_section.some((col) => col.length)) {
-		sections.push(current_section);
-	}
-	return sections;
 });
 
 const form_data_resource = createResource({


### PR DESCRIPTION
Render custom forms with their Section Break / Column Break layout (mirrors #208 for the Event Proposal form), with responsive single-column stacking on mobile.

## Demo

**ToDo**
![ToDo custom form](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/todo-form.png)

**Sponsorship Enquiry**
![Sponsorship Enquiry custom form](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/sponsorship-form.png)

Closes #209
