### PR TITLE
feat: allow excluding fields per custom form

### DIFF
--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -48,14 +48,31 @@ def _get_dial_codes() -> list:
 	return codes
 
 
-def get_form_fields(doctype: str, exclude_fields: set, with_layout_breaks: bool = False) -> list:
+def is_renderable_form_field(df, exclude_fields: set) -> bool:
+	if df.fieldname in exclude_fields:
+		return False
+	if df.fieldtype in LAYOUT_FIELDTYPES:
+		return False
+	if df.hidden or df.read_only:
+		return False
+	return True
+
+
+def get_form_fields(
+	doctype: str,
+	exclude_fields: set,
+	with_layout_breaks: bool = False,
+	include_fields: set | None = None,
+) -> list:
 	meta = frappe.get_meta(doctype)
 	fields = []
 	for df in meta.fields:
-		if df.fieldname in exclude_fields:
-			continue
-		if df.fieldtype in LAYOUT_FIELDTYPES:
-			if with_layout_breaks and df.fieldtype in LAYOUT_BREAK_FIELDTYPES:
+		if not is_renderable_form_field(df, exclude_fields):
+			if (
+				with_layout_breaks
+				and df.fieldtype in LAYOUT_BREAK_FIELDTYPES
+				and df.fieldname not in exclude_fields
+			):
 				fields.append(
 					{
 						"fieldname": df.fieldname,
@@ -64,9 +81,7 @@ def get_form_fields(doctype: str, exclude_fields: set, with_layout_breaks: bool 
 					}
 				)
 			continue
-		if df.hidden:
-			continue
-		if df.read_only:
+		if include_fields is not None and df.fieldname not in include_fields:
 			continue
 		default_value = df.default
 		if default_value:
@@ -148,6 +163,45 @@ def get_auto_set_fields(form_doctype: str):
 	return auto_set
 
 
+def parse_visible_fields(value: str | None) -> set | None:
+	if not value:
+		return None
+	fieldnames = {fieldname.strip() for fieldname in value.split(",") if fieldname.strip()}
+	return fieldnames or None
+
+
+def get_renderable_fields(form_doctype: str, exclude_fields: set) -> dict:
+	meta = frappe.get_meta(form_doctype)
+	return {df.fieldname: df for df in meta.fields if is_renderable_form_field(df, exclude_fields)}
+
+
+def validate_visible_fields(form_doctype: str, visible_fields: str | None) -> None:
+	include_fields = parse_visible_fields(visible_fields)
+	if not include_fields:
+		return
+
+	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(get_auto_set_fields(form_doctype).keys())
+	renderable = get_renderable_fields(form_doctype, exclude_fields)
+
+	unknown = include_fields - set(renderable)
+	if unknown:
+		frappe.throw(
+			_("These fields cannot be shown on the {0} form: {1}").format(
+				form_doctype, ", ".join(sorted(unknown))
+			)
+		)
+
+	missing_mandatory = {
+		fieldname for fieldname, df in renderable.items() if df.reqd and fieldname not in include_fields
+	}
+	if missing_mandatory:
+		frappe.throw(
+			_("Visible Fields for the {0} form must include the mandatory fields: {1}").format(
+				form_doctype, ", ".join(sorted(missing_mandatory))
+			)
+		)
+
+
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_custom_form_data(event_route: str, form_route: str) -> dict:
 	event_doc, form_row = validate_custom_form(event_route, form_route)
@@ -190,7 +244,8 @@ def get_custom_form_data(event_route: str, form_route: str) -> dict:
 
 	auto_set = get_auto_set_fields(form_doctype)
 	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys())
-	form_fields = get_form_fields(form_doctype, exclude_fields)
+	include_fields = parse_visible_fields(form_row.visible_fields)
+	form_fields = get_form_fields(form_doctype, exclude_fields, include_fields=include_fields)
 
 	form_doctype_meta = frappe.get_meta(form_doctype)
 	custom_fields = []
@@ -247,6 +302,7 @@ def submit_custom_form(
 
 	auto_set = get_auto_set_fields(form_doctype)
 	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys())
+	include_fields = parse_visible_fields(form_row.visible_fields)
 
 	doc_data = {"doctype": form_doctype}
 
@@ -256,14 +312,16 @@ def submit_custom_form(
 		elif source == "session_user":
 			doc_data[field] = frappe.session.user
 
-	allowed_fieldnames = {f["fieldname"] for f in get_form_fields(form_doctype, exclude_fields)}
+	allowed_fieldnames = set(get_renderable_fields(form_doctype, exclude_fields))
+	if include_fields is not None:
+		allowed_fieldnames &= include_fields
 	for fieldname, value in data.items():
 		if fieldname in allowed_fieldnames:
 			doc_data[fieldname] = value
 
 	meta = frappe.get_meta(form_doctype)
 	for df in meta.fields:
-		if df.fieldtype == "Table" and df.fieldname not in exclude_fields:
+		if df.fieldtype == "Table" and df.fieldname in allowed_fieldnames:
 			if df.fieldname in data and isinstance(data[df.fieldname], list):
 				doc_data[df.fieldname] = data[df.fieldname]
 

--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -62,7 +62,6 @@ def get_form_fields(
 	doctype: str,
 	exclude_fields: set,
 	with_layout_breaks: bool = False,
-	include_fields: set | None = None,
 ) -> list:
 	meta = frappe.get_meta(doctype)
 	fields = []
@@ -80,8 +79,6 @@ def get_form_fields(
 						"label": df.label or "",
 					}
 				)
-			continue
-		if include_fields is not None and df.fieldname not in include_fields:
 			continue
 		default_value = df.default
 		if default_value:
@@ -163,7 +160,7 @@ def get_auto_set_fields(form_doctype: str):
 	return auto_set
 
 
-def parse_visible_fields(value: str | None) -> set | None:
+def parse_excluded_fields(value: str | None) -> set | None:
 	if not value:
 		return None
 	fieldnames = {fieldname.strip() for fieldname in value.split(",") if fieldname.strip()}
@@ -175,29 +172,33 @@ def get_renderable_fields(form_doctype: str, exclude_fields: set) -> dict:
 	return {df.fieldname: df for df in meta.fields if is_renderable_form_field(df, exclude_fields)}
 
 
-def validate_visible_fields(form_doctype: str, visible_fields: str | None) -> None:
-	include_fields = parse_visible_fields(visible_fields)
-	if not include_fields:
+def validate_excluded_fields(form_doctype: str, excluded_fields: str | None) -> None:
+	excluded = parse_excluded_fields(excluded_fields)
+	if not excluded:
 		return
 
-	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(get_auto_set_fields(form_doctype).keys())
-	renderable = get_renderable_fields(form_doctype, exclude_fields)
+	meta = frappe.get_meta(form_doctype)
+	system_exclude = STANDARD_EXCLUDE_FIELDS | set(get_auto_set_fields(form_doctype).keys())
+	# Blacklisting a system/auto-set field is a harmless no-op (it is never rendered anyway),
+	# so they count as known names; only genuine typos are rejected.
+	known_fieldnames = {df.fieldname for df in meta.fields} | system_exclude
 
-	unknown = include_fields - set(renderable)
+	unknown = excluded - known_fieldnames
 	if unknown:
 		frappe.throw(
-			_("These fields cannot be shown on the {0} form: {1}").format(
+			_("These fields do not exist on the {0} form: {1}").format(
 				form_doctype, ", ".join(sorted(unknown))
 			)
 		)
 
-	missing_mandatory = {
-		fieldname for fieldname, df in renderable.items() if df.reqd and fieldname not in include_fields
+	renderable = get_renderable_fields(form_doctype, system_exclude)
+	hidden_mandatory = {
+		fieldname for fieldname in excluded if fieldname in renderable and renderable[fieldname].reqd
 	}
-	if missing_mandatory:
+	if hidden_mandatory:
 		frappe.throw(
-			_("Visible Fields for the {0} form must include the mandatory fields: {1}").format(
-				form_doctype, ", ".join(sorted(missing_mandatory))
+			_("These mandatory fields cannot be hidden on the {0} form: {1}").format(
+				form_doctype, ", ".join(sorted(hidden_mandatory))
 			)
 		)
 
@@ -243,9 +244,9 @@ def get_custom_form_data(event_route: str, form_route: str) -> dict:
 		}
 
 	auto_set = get_auto_set_fields(form_doctype)
-	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys())
-	include_fields = parse_visible_fields(form_row.visible_fields)
-	form_fields = get_form_fields(form_doctype, exclude_fields, include_fields=include_fields)
+	excluded_fields = parse_excluded_fields(form_row.excluded_fields) or set()
+	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys()) | excluded_fields
+	form_fields = get_form_fields(form_doctype, exclude_fields)
 
 	form_doctype_meta = frappe.get_meta(form_doctype)
 	custom_fields = []
@@ -301,8 +302,8 @@ def submit_custom_form(
 	custom_fields_data = frappe.parse_json(custom_fields_data) or {}
 
 	auto_set = get_auto_set_fields(form_doctype)
-	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys())
-	include_fields = parse_visible_fields(form_row.visible_fields)
+	excluded_fields = parse_excluded_fields(form_row.excluded_fields) or set()
+	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys()) | excluded_fields
 
 	doc_data = {"doctype": form_doctype}
 
@@ -313,8 +314,6 @@ def submit_custom_form(
 			doc_data[field] = frappe.session.user
 
 	allowed_fieldnames = set(get_renderable_fields(form_doctype, exclude_fields))
-	if include_fields is not None:
-		allowed_fieldnames &= include_fields
 	for fieldname, value in data.items():
 		if fieldname in allowed_fieldnames:
 			doc_data[fieldname] = value

--- a/buzz/api/test_forms.py
+++ b/buzz/api/test_forms.py
@@ -5,9 +5,9 @@ from buzz.api.forms import (
 	STANDARD_EXCLUDE_FIELDS,
 	get_custom_form_data,
 	get_form_fields,
-	parse_visible_fields,
+	parse_excluded_fields,
 	submit_custom_form,
-	validate_visible_fields,
+	validate_excluded_fields,
 )
 
 # Renderable Talk Proposal fields (after STANDARD_EXCLUDE_FIELDS + auto-set event/submitted_by):
@@ -25,55 +25,54 @@ def ensure_prompt_named_record(doctype, name):
 	return doc.name
 
 
-class TestParseVisibleFields(IntegrationTestCase):
+class TestParseExcludedFields(IntegrationTestCase):
 	def test_blank_returns_none(self):
-		self.assertIsNone(parse_visible_fields(None))
-		self.assertIsNone(parse_visible_fields(""))
-		self.assertIsNone(parse_visible_fields("   "))
-		self.assertIsNone(parse_visible_fields(", ,,"))
+		self.assertIsNone(parse_excluded_fields(None))
+		self.assertIsNone(parse_excluded_fields(""))
+		self.assertIsNone(parse_excluded_fields("   "))
+		self.assertIsNone(parse_excluded_fields(", ,,"))
 
 	def test_trims_and_drops_empties(self):
-		self.assertEqual(parse_visible_fields("a, b ,,c"), {"a", "b", "c"})
+		self.assertEqual(parse_excluded_fields("a, b ,,c"), {"a", "b", "c"})
 
 	def test_single_field(self):
-		self.assertEqual(parse_visible_fields("title"), {"title"})
+		self.assertEqual(parse_excluded_fields("title"), {"title"})
 
 
 class TestGetFormFields(IntegrationTestCase):
-	def test_include_fields_returns_only_subset(self):
-		subset = {"title", "description", "speakers"}
-		fields = get_form_fields("Talk Proposal", TALK_PROPOSAL_EXCLUDE, include_fields=subset)
+	def test_excluding_a_field_drops_it(self):
+		exclude_fields = TALK_PROPOSAL_EXCLUDE | {"phone"}
+		fields = get_form_fields("Talk Proposal", exclude_fields)
 		returned = {f["fieldname"] for f in fields}
-		self.assertEqual(returned, subset)
 		self.assertNotIn("phone", returned)
+		self.assertTrue({"title", "description", "speakers"} <= returned)
 
-	def test_none_returns_all_renderable(self):
-		fields = get_form_fields("Talk Proposal", TALK_PROPOSAL_EXCLUDE, include_fields=None)
+	def test_no_extra_exclude_returns_all_renderable(self):
+		fields = get_form_fields("Talk Proposal", TALK_PROPOSAL_EXCLUDE)
 		returned = {f["fieldname"] for f in fields}
-		self.assertEqual(returned, {"title", "description", "speakers", "phone"})
+		self.assertTrue({"title", "description", "speakers", "phone"} <= returned)
 
-	def test_layout_breaks_pass_through_include_fields(self):
-		# With layout breaks on, section/column breaks are emitted even if not in include_fields.
-		subset = {"title"}
-		fields = get_form_fields(
-			"Talk Proposal", TALK_PROPOSAL_EXCLUDE, with_layout_breaks=True, include_fields=subset
-		)
+	def test_layout_breaks_pass_through(self):
+		# With layout breaks on, section/column breaks are emitted even when other fields are excluded.
+		exclude_fields = TALK_PROPOSAL_EXCLUDE | {"description", "speakers", "phone"}
+		fields = get_form_fields("Talk Proposal", exclude_fields, with_layout_breaks=True)
 		real_fields = {
 			f["fieldname"] for f in fields if f["fieldtype"] not in ("Section Break", "Column Break")
 		}
 		breaks = [f for f in fields if f["fieldtype"] in ("Section Break", "Column Break")]
-		self.assertEqual(real_fields, {"title"})
+		self.assertIn("title", real_fields)
+		self.assertFalse({"description", "speakers", "phone"} & real_fields)
 		self.assertTrue(breaks, "expected layout breaks to pass through")
 
 
-class TestCustomFormVisibleFields(IntegrationTestCase):
+class TestCustomFormExcludedFields(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		cls.category = ensure_prompt_named_record("Event Category", "Test Forms Category")
 		cls.host = ensure_prompt_named_record("Event Host", "Test Forms Host")
 
-	def make_event(self, visible_fields, form_route=None, publish=1):
+	def make_event(self, excluded_fields, form_route=None, publish=1):
 		form_route = form_route or f"propose-{frappe.generate_hash(length=6)}"
 		event = frappe.new_doc("Buzz Event")
 		event.update(
@@ -96,29 +95,29 @@ class TestCustomFormVisibleFields(IntegrationTestCase):
 				"form_doctype": "Talk Proposal",
 				"route": form_route,
 				"publish": publish,
-				"visible_fields": visible_fields,
+				"excluded_fields": excluded_fields,
 			},
 		)
 		event.insert(ignore_permissions=True)
 		event.reload()
 		return event, form_route
 
-	def test_get_custom_form_data_returns_only_visible_fields(self):
-		event, form_route = self.make_event("title, description, speakers")
+	def test_get_custom_form_data_hides_excluded_fields(self):
+		event, form_route = self.make_event("phone")
 		data = get_custom_form_data(event.route, form_route)
 		returned = {f["fieldname"] for f in data["form_fields"]}
-		self.assertEqual(returned, {"title", "description", "speakers"})
 		self.assertNotIn("phone", returned)
+		self.assertTrue({"title", "description", "speakers"} <= returned)
 
-	def test_get_custom_form_data_empty_visible_fields_returns_all(self):
+	def test_get_custom_form_data_empty_excluded_fields_returns_all(self):
 		event, form_route = self.make_event("")
 		data = get_custom_form_data(event.route, form_route)
 		returned = {f["fieldname"] for f in data["form_fields"]}
-		self.assertEqual(returned, {"title", "description", "speakers", "phone"})
+		self.assertTrue({"title", "description", "speakers", "phone"} <= returned)
 
-	def test_submit_drops_non_visible_field_value(self):
-		# phone is NOT in visible_fields -> a posted phone value must be dropped.
-		event, form_route = self.make_event("title, description, speakers")
+	def test_submit_drops_excluded_field_value(self):
+		# phone is excluded -> a posted phone value must be dropped.
+		event, form_route = self.make_event("phone")
 		submit_custom_form(
 			event.route,
 			form_route,
@@ -132,35 +131,45 @@ class TestCustomFormVisibleFields(IntegrationTestCase):
 		created = frappe.get_last_doc("Talk Proposal", filters={"title": "Hidden Phone Test"})
 		self.assertEqual(str(created.event), str(event.name))
 		self.assertFalse(created.phone, f"phone should be dropped but was {created.phone!r}")
+		# Non-excluded fields (and child rows) must still be written.
+		self.assertEqual(created.title, "Hidden Phone Test")
+		self.assertEqual(created.description, "<p>desc</p>")
+		self.assertEqual(len(created.speakers), 1)
+		self.assertEqual(created.speakers[0].first_name, "Jane")
+		self.assertEqual(created.speakers[0].email, "jane@example.com")
 
 
-class TestValidateVisibleFields(IntegrationTestCase):
-	def test_omitting_mandatory_field_throws(self):
-		# speakers is mandatory; omit it.
+class TestValidateExcludedFields(IntegrationTestCase):
+	def test_hiding_mandatory_field_throws(self):
+		# speakers is mandatory; it cannot be hidden.
 		with self.assertRaises(frappe.ValidationError):
-			validate_visible_fields("Talk Proposal", "title, description")
+			validate_excluded_fields("Talk Proposal", "speakers")
 
 	def test_unknown_field_throws(self):
 		with self.assertRaises(frappe.ValidationError):
-			validate_visible_fields("Talk Proposal", "title, description, speakers, not_a_field")
+			validate_excluded_fields("Talk Proposal", "phone, not_a_field")
 
-	def test_valid_subset_passes(self):
-		# All mandatory (title, speakers) included + an optional one. Should not raise.
-		validate_visible_fields("Talk Proposal", "title, speakers, description")
+	def test_hiding_optional_field_passes(self):
+		# phone is optional -> safe to hide.
+		validate_excluded_fields("Talk Proposal", "phone")
+
+	def test_system_field_is_noop(self):
+		# Auto-set/system fields are never rendered; listing them is a harmless no-op.
+		validate_excluded_fields("Talk Proposal", "event, submitted_by")
 
 	def test_blank_is_noop(self):
-		validate_visible_fields("Talk Proposal", "")
-		validate_visible_fields("Talk Proposal", None)
+		validate_excluded_fields("Talk Proposal", "")
+		validate_excluded_fields("Talk Proposal", None)
 
 
-class TestBuzzEventSaveValidatesVisibleFields(IntegrationTestCase):
+class TestBuzzEventSaveValidatesExcludedFields(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		cls.category = ensure_prompt_named_record("Event Category", "Test Forms Category")
 		cls.host = ensure_prompt_named_record("Event Host", "Test Forms Host")
 
-	def make_event_doc(self, visible_fields):
+	def make_event_doc(self, excluded_fields):
 		event = frappe.new_doc("Buzz Event")
 		event.update(
 			{
@@ -182,22 +191,22 @@ class TestBuzzEventSaveValidatesVisibleFields(IntegrationTestCase):
 				"form_doctype": "Talk Proposal",
 				"route": f"propose-{frappe.generate_hash(length=6)}",
 				"publish": 1,
-				"visible_fields": visible_fields,
+				"excluded_fields": excluded_fields,
 			},
 		)
 		return event
 
-	def test_save_with_missing_mandatory_throws(self):
-		event = self.make_event_doc("title, description")
+	def test_save_hiding_mandatory_throws(self):
+		event = self.make_event_doc("speakers")
 		with self.assertRaises(frappe.ValidationError):
 			event.insert(ignore_permissions=True)
 
 	def test_save_with_unknown_field_throws(self):
-		event = self.make_event_doc("title, speakers, bogus_field")
+		event = self.make_event_doc("phone, bogus_field")
 		with self.assertRaises(frappe.ValidationError):
 			event.insert(ignore_permissions=True)
 
-	def test_save_with_valid_subset_succeeds(self):
-		event = self.make_event_doc("title, speakers, description")
+	def test_save_hiding_optional_field_succeeds(self):
+		event = self.make_event_doc("phone")
 		event.insert(ignore_permissions=True)
 		self.assertTrue(frappe.db.exists("Buzz Event", event.name))

--- a/buzz/api/test_forms.py
+++ b/buzz/api/test_forms.py
@@ -1,0 +1,203 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.forms import (
+	STANDARD_EXCLUDE_FIELDS,
+	get_custom_form_data,
+	get_form_fields,
+	parse_visible_fields,
+	submit_custom_form,
+	validate_visible_fields,
+)
+
+# Renderable Talk Proposal fields (after STANDARD_EXCLUDE_FIELDS + auto-set event/submitted_by):
+#   title (reqd, Data), description (Text Editor), speakers (reqd, Table), phone (Phone)
+TALK_PROPOSAL_EXCLUDE = STANDARD_EXCLUDE_FIELDS | {"event", "submitted_by"}
+
+
+def ensure_prompt_named_record(doctype, name):
+	# Event Category / Event Host use autoname "prompt" -> name set explicitly.
+	if frappe.db.exists(doctype, name):
+		return name
+	doc = frappe.new_doc(doctype)
+	doc.name = name
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestParseVisibleFields(IntegrationTestCase):
+	def test_blank_returns_none(self):
+		self.assertIsNone(parse_visible_fields(None))
+		self.assertIsNone(parse_visible_fields(""))
+		self.assertIsNone(parse_visible_fields("   "))
+		self.assertIsNone(parse_visible_fields(", ,,"))
+
+	def test_trims_and_drops_empties(self):
+		self.assertEqual(parse_visible_fields("a, b ,,c"), {"a", "b", "c"})
+
+	def test_single_field(self):
+		self.assertEqual(parse_visible_fields("title"), {"title"})
+
+
+class TestGetFormFields(IntegrationTestCase):
+	def test_include_fields_returns_only_subset(self):
+		subset = {"title", "description", "speakers"}
+		fields = get_form_fields("Talk Proposal", TALK_PROPOSAL_EXCLUDE, include_fields=subset)
+		returned = {f["fieldname"] for f in fields}
+		self.assertEqual(returned, subset)
+		self.assertNotIn("phone", returned)
+
+	def test_none_returns_all_renderable(self):
+		fields = get_form_fields("Talk Proposal", TALK_PROPOSAL_EXCLUDE, include_fields=None)
+		returned = {f["fieldname"] for f in fields}
+		self.assertEqual(returned, {"title", "description", "speakers", "phone"})
+
+	def test_layout_breaks_pass_through_include_fields(self):
+		# With layout breaks on, section/column breaks are emitted even if not in include_fields.
+		subset = {"title"}
+		fields = get_form_fields(
+			"Talk Proposal", TALK_PROPOSAL_EXCLUDE, with_layout_breaks=True, include_fields=subset
+		)
+		real_fields = {
+			f["fieldname"] for f in fields if f["fieldtype"] not in ("Section Break", "Column Break")
+		}
+		breaks = [f for f in fields if f["fieldtype"] in ("Section Break", "Column Break")]
+		self.assertEqual(real_fields, {"title"})
+		self.assertTrue(breaks, "expected layout breaks to pass through")
+
+
+class TestCustomFormVisibleFields(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Test Forms Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Test Forms Host")
+
+	def make_event(self, visible_fields, form_route=None, publish=1):
+		form_route = form_route or f"propose-{frappe.generate_hash(length=6)}"
+		event = frappe.new_doc("Buzz Event")
+		event.update(
+			{
+				"title": f"Test Event {frappe.generate_hash(length=6)}",
+				"start_date": "2030-01-01",
+				"end_date": "2030-01-01",
+				"start_time": "10:00:00",
+				"end_time": "18:00:00",
+				"medium": "Online",
+				"category": self.category,
+				"host": self.host,
+				"is_published": 1,
+			}
+		)
+		event.set("custom_forms", [])
+		event.append(
+			"custom_forms",
+			{
+				"form_doctype": "Talk Proposal",
+				"route": form_route,
+				"publish": publish,
+				"visible_fields": visible_fields,
+			},
+		)
+		event.insert(ignore_permissions=True)
+		event.reload()
+		return event, form_route
+
+	def test_get_custom_form_data_returns_only_visible_fields(self):
+		event, form_route = self.make_event("title, description, speakers")
+		data = get_custom_form_data(event.route, form_route)
+		returned = {f["fieldname"] for f in data["form_fields"]}
+		self.assertEqual(returned, {"title", "description", "speakers"})
+		self.assertNotIn("phone", returned)
+
+	def test_get_custom_form_data_empty_visible_fields_returns_all(self):
+		event, form_route = self.make_event("")
+		data = get_custom_form_data(event.route, form_route)
+		returned = {f["fieldname"] for f in data["form_fields"]}
+		self.assertEqual(returned, {"title", "description", "speakers", "phone"})
+
+	def test_submit_drops_non_visible_field_value(self):
+		# phone is NOT in visible_fields -> a posted phone value must be dropped.
+		event, form_route = self.make_event("title, description, speakers")
+		submit_custom_form(
+			event.route,
+			form_route,
+			data={
+				"title": "Hidden Phone Test",
+				"description": "<p>desc</p>",
+				"speakers": [{"first_name": "Jane", "email": "jane@example.com"}],
+				"phone": "+919999999999",
+			},
+		)
+		created = frappe.get_last_doc("Talk Proposal", filters={"title": "Hidden Phone Test"})
+		self.assertEqual(str(created.event), str(event.name))
+		self.assertFalse(created.phone, f"phone should be dropped but was {created.phone!r}")
+
+
+class TestValidateVisibleFields(IntegrationTestCase):
+	def test_omitting_mandatory_field_throws(self):
+		# speakers is mandatory; omit it.
+		with self.assertRaises(frappe.ValidationError):
+			validate_visible_fields("Talk Proposal", "title, description")
+
+	def test_unknown_field_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			validate_visible_fields("Talk Proposal", "title, description, speakers, not_a_field")
+
+	def test_valid_subset_passes(self):
+		# All mandatory (title, speakers) included + an optional one. Should not raise.
+		validate_visible_fields("Talk Proposal", "title, speakers, description")
+
+	def test_blank_is_noop(self):
+		validate_visible_fields("Talk Proposal", "")
+		validate_visible_fields("Talk Proposal", None)
+
+
+class TestBuzzEventSaveValidatesVisibleFields(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Test Forms Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Test Forms Host")
+
+	def make_event_doc(self, visible_fields):
+		event = frappe.new_doc("Buzz Event")
+		event.update(
+			{
+				"title": f"Test Event {frappe.generate_hash(length=6)}",
+				"start_date": "2030-01-01",
+				"end_date": "2030-01-01",
+				"start_time": "10:00:00",
+				"end_time": "18:00:00",
+				"medium": "Online",
+				"category": self.category,
+				"host": self.host,
+				"is_published": 1,
+			}
+		)
+		event.set("custom_forms", [])
+		event.append(
+			"custom_forms",
+			{
+				"form_doctype": "Talk Proposal",
+				"route": f"propose-{frappe.generate_hash(length=6)}",
+				"publish": 1,
+				"visible_fields": visible_fields,
+			},
+		)
+		return event
+
+	def test_save_with_missing_mandatory_throws(self):
+		event = self.make_event_doc("title, description")
+		with self.assertRaises(frappe.ValidationError):
+			event.insert(ignore_permissions=True)
+
+	def test_save_with_unknown_field_throws(self):
+		event = self.make_event_doc("title, speakers, bogus_field")
+		with self.assertRaises(frappe.ValidationError):
+			event.insert(ignore_permissions=True)
+
+	def test_save_with_valid_subset_succeeds(self):
+		event = self.make_event_doc("title, speakers, description")
+		event.insert(ignore_permissions=True)
+		self.assertTrue(frappe.db.exists("Buzz Event", event.name))

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -7,7 +7,7 @@ from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils.data import get_time, time_diff_in_seconds
 
-from buzz.api.forms import validate_visible_fields
+from buzz.api.forms import validate_excluded_fields
 from buzz.utils import only_if_app_installed
 
 
@@ -84,8 +84,8 @@ class BuzzEvent(Document):
 
 	def validate_custom_forms(self):
 		for form in self.custom_forms:
-			if form.visible_fields:
-				validate_visible_fields(form.form_doctype, form.visible_fields)
+			if form.excluded_fields:
+				validate_excluded_fields(form.form_doctype, form.excluded_fields)
 
 	def validate_schedule(self):
 		end_date = self.end_date or self.start_date

--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -7,6 +7,7 @@ from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils.data import get_time, time_diff_in_seconds
 
+from buzz.api.forms import validate_visible_fields
 from buzz.utils import only_if_app_installed
 
 
@@ -79,6 +80,12 @@ class BuzzEvent(Document):
 		self.validate_route()
 		self.validate_tax_settings()
 		self.validate_guest_verification_config()
+		self.validate_custom_forms()
+
+	def validate_custom_forms(self):
+		for form in self.custom_forms:
+			if form.visible_fields:
+				validate_visible_fields(form.form_doctype, form.visible_fields)
 
 	def validate_schedule(self):
 		end_date = self.end_date or self.start_date

--- a/buzz/events/doctype/buzz_event_form/buzz_event_form.json
+++ b/buzz/events/doctype/buzz_event_form/buzz_event_form.json
@@ -13,7 +13,7 @@
   "login_required",
   "column_break_main",
   "auto_close_at",
-  "visible_fields",
+  "excluded_fields",
   "section_break_success",
   "success_title",
   "success_message",
@@ -61,10 +61,10 @@
    "label": "Auto Close At"
   },
   {
-   "description": "Comma-separated field names. If set, only these fields are shown on the form (others hidden). Leave empty to show all. Mandatory fields must be included.",
-   "fieldname": "visible_fields",
+   "description": "Comma-separated field names to hide from the form (others are shown). Leave empty to show all. Mandatory fields cannot be hidden.",
+   "fieldname": "excluded_fields",
    "fieldtype": "Small Text",
-   "label": "Visible Fields"
+   "label": "Excluded Fields"
   },
   {
    "fieldname": "section_break_success",

--- a/buzz/events/doctype/buzz_event_form/buzz_event_form.json
+++ b/buzz/events/doctype/buzz_event_form/buzz_event_form.json
@@ -13,6 +13,7 @@
   "login_required",
   "column_break_main",
   "auto_close_at",
+  "visible_fields",
   "section_break_success",
   "success_title",
   "success_message",
@@ -58,6 +59,12 @@
    "fieldname": "auto_close_at",
    "fieldtype": "Datetime",
    "label": "Auto Close At"
+  },
+  {
+   "description": "Comma-separated field names. If set, only these fields are shown on the form (others hidden). Leave empty to show all. Mandatory fields must be included.",
+   "fieldname": "visible_fields",
+   "fieldtype": "Small Text",
+   "label": "Visible Fields"
   },
   {
    "fieldname": "section_break_success",

--- a/buzz/events/doctype/buzz_event_form/buzz_event_form.py
+++ b/buzz/events/doctype/buzz_event_form/buzz_event_form.py
@@ -24,6 +24,7 @@ class BuzzEventForm(Document):
 		route: DF.Data
 		success_message: DF.MarkdownEditor | None
 		success_title: DF.Data | None
+		visible_fields: DF.SmallText | None
 	# end: auto-generated types
 
 	def validate(self):

--- a/buzz/events/doctype/buzz_event_form/buzz_event_form.py
+++ b/buzz/events/doctype/buzz_event_form/buzz_event_form.py
@@ -24,7 +24,7 @@ class BuzzEventForm(Document):
 		route: DF.Data
 		success_message: DF.MarkdownEditor | None
 		success_title: DF.Data | None
-		visible_fields: DF.SmallText | None
+		excluded_fields: DF.SmallText | None
 	# end: auto-generated types
 
 	def validate(self):


### PR DESCRIPTION
Adds an **Excluded Fields** blacklist (Small Text, comma-separated) on the Buzz Event Form child table: listed fields are hidden from the public custom form, everything else renders. Leave empty to show all (no change for existing forms).

- Saved-time validation: the list **cannot include any mandatory field** of the form DocType (errors on save otherwise) and **rejects unknown/non-renderable field names** (typo guard). Auto-set/system fields (`event`, `submitted_by`, etc.) are already non-rendered, so listing them is a harmless no-op.
- `submit_custom_form` drops values posted for excluded fields (incl. child tables), so hiding a field also closes it on the write path.

## Configuration

Admins set the comma-separated list on the form row in Desk (Buzz Event → Forms):

![excluded fields config](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/ef-config-field.png)

## Demo

With `excluded_fields = "phone"` the DocType's **Phone** field is hidden, layout stays clean (desktop + mobile):

![filtered form desktop](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/ef-form-desktop.png)
![filtered form mobile](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/ef-form-mobile.png)

Clearing `excluded_fields` restores the full form (back-compat, empty = show all):

![all fields](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/ef-form-empty-all.png)

Validation (on Buzz Event save) when a mandatory field is excluded:
> These mandatory fields cannot be hidden on the Talk Proposal form: description

![validation error](https://raw.githubusercontent.com/BuildWithHussain/buzz/assets/pr-209-demo/ef-validation-error.png)

## Tests

`buzz/api/test_forms.py` — 17 tests (real DB): parsing, blacklist filtering, back-compat (empty = all), submit drops excluded values (and keeps the rest), and save-time validation (excluding-mandatory + unknown-field throws, system-field no-op). All green.

Closes #221