### PR TITLE
fix: filter Sponsorship Enquiry tier by event (Desk + public form)

### DIFF
--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -62,6 +62,7 @@ def get_form_fields(
 	doctype: str,
 	exclude_fields: set,
 	with_layout_breaks: bool = False,
+	event: str | None = None,
 ) -> list:
 	meta = frappe.get_meta(doctype)
 	fields = []
@@ -99,8 +100,12 @@ def get_form_fields(
 			"description": df.description,
 		}
 		if df.fieldtype == "Link" and df.options:
+			link_filters = {}
+			if event and frappe.get_meta(df.options).has_field("event"):
+				link_filters["event"] = event
 			link_values = frappe.get_all(
 				df.options,
+				filters=link_filters,
 				fields=["name"],
 				limit_page_length=0,
 				order_by="name asc",
@@ -246,7 +251,7 @@ def get_custom_form_data(event_route: str, form_route: str) -> dict:
 	auto_set = get_auto_set_fields(form_doctype)
 	excluded_fields = parse_excluded_fields(form_row.excluded_fields) or set()
 	exclude_fields = STANDARD_EXCLUDE_FIELDS | set(auto_set.keys()) | excluded_fields
-	form_fields = get_form_fields(form_doctype, exclude_fields, with_layout_breaks=True)
+	form_fields = get_form_fields(form_doctype, exclude_fields, with_layout_breaks=True, event=event_doc.name)
 
 	form_doctype_meta = frappe.get_meta(form_doctype)
 	custom_fields = []

--- a/buzz/api/test_forms.py
+++ b/buzz/api/test_forms.py
@@ -139,6 +139,62 @@ class TestCustomFormExcludedFields(IntegrationTestCase):
 		self.assertEqual(created.speakers[0].email, "jane@example.com")
 
 
+class TestCustomFormLinkEventFilter(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Test Forms Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Test Forms Host")
+
+	def make_sponsorship_event(self):
+		form_route = f"sponsor-{frappe.generate_hash(length=6)}"
+		event = frappe.new_doc("Buzz Event")
+		event.update(
+			{
+				"title": f"Test Event {frappe.generate_hash(length=6)}",
+				"start_date": "2030-01-01",
+				"end_date": "2030-01-01",
+				"start_time": "10:00:00",
+				"end_time": "18:00:00",
+				"medium": "Online",
+				"category": self.category,
+				"host": self.host,
+				"is_published": 1,
+			}
+		)
+		event.append(
+			"custom_forms",
+			{"form_doctype": "Sponsorship Enquiry", "route": form_route, "publish": 1},
+		)
+		event.insert(ignore_permissions=True)
+		return event, form_route
+
+	def make_tier(self, event_name, title):
+		tier = frappe.new_doc("Sponsorship Tier")
+		tier.update({"event": event_name, "title": title, "price": 100, "currency": "INR"})
+		tier.insert(ignore_permissions=True)
+		return tier.name
+
+	def test_tier_options_filtered_to_form_event(self):
+		event_a, route_a = self.make_sponsorship_event()
+		event_b, _ = self.make_sponsorship_event()
+		tier_a = self.make_tier(event_a.name, "Gold A")
+		tier_b = self.make_tier(event_b.name, "Gold B")
+
+		data = get_custom_form_data(event_a.route, route_a)
+		tier_field = next(f for f in data["form_fields"] if f["fieldname"] == "tier")
+
+		self.assertIn(tier_a, tier_field["link_options"])
+		self.assertNotIn(tier_b, tier_field["link_options"], "tiers from other events must not leak")
+
+	def test_link_field_without_event_is_not_filtered(self):
+		# Country has no `event` field -> it must keep returning the full list.
+		event_a, route_a = self.make_sponsorship_event()
+		data = get_custom_form_data(event_a.route, route_a)
+		country_field = next(f for f in data["form_fields"] if f["fieldname"] == "country")
+		self.assertTrue(len(country_field["link_options"]) > 1)
+
+
 class TestValidateExcludedFields(IntegrationTestCase):
 	def test_hiding_mandatory_field_throws(self):
 		# speakers is mandatory; it cannot be hidden.

--- a/buzz/proposals/doctype/sponsorship_enquiry/sponsorship_enquiry.js
+++ b/buzz/proposals/doctype/sponsorship_enquiry/sponsorship_enquiry.js
@@ -2,6 +2,22 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Sponsorship Enquiry", {
+	setup(frm) {
+		frm.set_query("tier", (doc) => {
+			return {
+				filters: {
+					event: doc.event,
+				},
+			};
+		});
+	},
+
+	event(frm) {
+		if (frm.doc.tier) {
+			frm.set_value("tier", null);
+		}
+	},
+
 	refresh(frm) {
 		if (!frm.doc.__islocal) {
 			if (frm.doc.status === "Approval Pending") {


### PR DESCRIPTION
Filters the Tier link field by the selected/owning Event:

- **Desk** Sponsorship Enquiry form: `set_query` on Tier by the chosen Event; clears Tier when the Event changes.
- **Public custom forms**: any Link field whose target doctype has an `event` field is now filtered to the form's own event (e.g. the Tier dropdown on a published event's sponsorship form only lists that event's tiers).

Includes tests for the public-form filtering.

Closes #238