### PR TITLE
fix: show title (not id) in custom form Link fields

### DIFF
--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -99,13 +99,7 @@ def get_form_fields(
 			"description": df.description,
 		}
 		if df.fieldtype == "Link" and df.options:
-			link_values = frappe.get_all(
-				df.options,
-				fields=["name"],
-				limit_page_length=0,
-				order_by="name asc",
-			)
-			field_data["link_options"] = [d.name for d in link_values]
+			field_data["link_options"] = get_link_field_options(df.options)
 		if df.fieldtype == "Table" and df.options:
 			child_meta = frappe.get_meta(df.options)
 			child_fields = []
@@ -126,6 +120,21 @@ def get_form_fields(
 			field_data["child_fields"] = child_fields
 		fields.append(field_data)
 	return fields
+
+
+def get_link_field_options(doctype: str) -> list[dict]:
+	meta = frappe.get_meta(doctype)
+	title_field = meta.title_field if meta.title_field and meta.title_field != "name" else None
+
+	fields = ["name"]
+	if title_field:
+		fields.append(title_field)
+
+	rows = frappe.get_all(doctype, fields=fields, limit_page_length=0, order_by="name asc")
+	return [
+		{"value": row.name, "label": (row.get(title_field) or row.name) if title_field else row.name}
+		for row in rows
+	]
 
 
 def validate_custom_form(event_route: str, form_route: str):

--- a/buzz/api/forms.py
+++ b/buzz/api/forms.py
@@ -124,17 +124,11 @@ def get_form_fields(
 
 def get_link_field_options(doctype: str) -> list[dict]:
 	meta = frappe.get_meta(doctype)
-	title_field = meta.title_field if meta.title_field and meta.title_field != "name" else None
+	title_field = meta.get_title_field()
 
-	fields = ["name"]
-	if title_field:
-		fields.append(title_field)
-
+	fields = ["name"] if title_field == "name" else ["name", title_field]
 	rows = frappe.get_all(doctype, fields=fields, limit_page_length=0, order_by="name asc")
-	return [
-		{"value": row.name, "label": (row.get(title_field) or row.name) if title_field else row.name}
-		for row in rows
-	]
+	return [{"value": row.name, "label": row.get(title_field) or row.name} for row in rows]
 
 
 def validate_custom_form(event_route: str, form_route: str):

--- a/buzz/api/test_forms.py
+++ b/buzz/api/test_forms.py
@@ -5,6 +5,7 @@ from buzz.api.forms import (
 	STANDARD_EXCLUDE_FIELDS,
 	get_custom_form_data,
 	get_form_fields,
+	get_link_field_options,
 	parse_excluded_fields,
 	submit_custom_form,
 	validate_excluded_fields,
@@ -63,6 +64,58 @@ class TestGetFormFields(IntegrationTestCase):
 		self.assertIn("title", real_fields)
 		self.assertFalse({"description", "speakers", "phone"} & real_fields)
 		self.assertTrue(breaks, "expected layout breaks to pass through")
+
+
+class TestGetLinkFieldOptions(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Test Forms Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Test Forms Host")
+
+	def make_tier(self, title="Gold Tier"):
+		event = frappe.new_doc("Buzz Event")
+		event.update(
+			{
+				"title": f"Test Event {frappe.generate_hash(length=6)}",
+				"start_date": "2030-01-01",
+				"end_date": "2030-01-01",
+				"start_time": "10:00:00",
+				"end_time": "18:00:00",
+				"medium": "Online",
+				"category": self.category,
+				"host": self.host,
+			}
+		)
+		event.insert(ignore_permissions=True)
+		tier = frappe.new_doc("Sponsorship Tier")
+		tier.update({"event": event.name, "title": title, "price": 1000, "currency": "INR"})
+		tier.insert(ignore_permissions=True)
+		return tier
+
+	def test_options_have_value_label_shape(self):
+		options = get_link_field_options("Event Host")
+		self.assertTrue(options)
+		self.assertTrue(all(set(option) == {"value", "label"} for option in options))
+
+	def test_no_title_field_label_falls_back_to_name(self):
+		# Event Host has no title field -> label mirrors the name.
+		match = next(o for o in get_link_field_options("Event Host") if o["value"] == self.host)
+		self.assertEqual(match["label"], self.host)
+
+	def test_title_field_used_as_label(self):
+		# Sponsorship Tier names are hashes; its title field is the readable label.
+		tier = self.make_tier(title="Gold Tier")
+		match = next(o for o in get_link_field_options("Sponsorship Tier") if o["value"] == tier.name)
+		self.assertEqual(match["label"], "Gold Tier")
+		self.assertNotEqual(match["value"], match["label"])
+
+	def test_null_title_falls_back_to_name(self):
+		tier = self.make_tier()
+		# Blank the title directly (bypasses the reqd validation) to exercise the fallback.
+		frappe.db.set_value("Sponsorship Tier", tier.name, "title", "")
+		match = next(o for o in get_link_field_options("Sponsorship Tier") if o["value"] == tier.name)
+		self.assertEqual(match["label"], tier.name)
 
 
 class TestCustomFormExcludedFields(IntegrationTestCase):

--- a/dashboard/src/components/CustomFieldInput.vue
+++ b/dashboard/src/components/CustomFieldInput.vue
@@ -220,9 +220,9 @@ const multiSelectProxy = computed({
 
 const linkFieldOptions = computed(() => {
 	if (!props.field.link_options) return [];
-	return props.field.link_options.map((name) => ({
-		label: name,
-		value: name,
+	return props.field.link_options.map((option) => ({
+		label: option.label,
+		value: option.value,
 	}));
 });
 


### PR DESCRIPTION
Custom form Link fields now display the linked doctype's title field as the option label, while still storing the document name as the value.

Closes #235