### PR TITLE
fix: skip event sponsor duplicate-check when enquiry is empty

### DIFF
--- a/buzz/events/doctype/event_sponsor/event_sponsor.py
+++ b/buzz/events/doctype/event_sponsor/event_sponsor.py
@@ -24,6 +24,9 @@ class EventSponsor(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		if not self.enquiry:
+			return
+
 		already_exists = frappe.db.exists(
 			"Event Sponsor", {"event": self.event, "enquiry": self.enquiry, "name": ("!=", self.name)}
 		)


### PR DESCRIPTION
Manually-added sponsors (no enquiry) on the same event were wrongly flagged as duplicates because `{"enquiry": None}` matches `enquiry IS NULL`; the check now only runs when an enquiry is set.