### PR TITLE
fix: scope Playwright login submit locator to Continue button

### DIFF
--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -16,8 +16,6 @@ export class LoginPage {
 		// Frappe login page selectors
 		this.emailInput = page.locator("#login_email");
 		this.passwordInput = page.locator("#login_password");
-		// Scope to the "Continue" submit button; the login page also renders a
-		// second "Send login link" button that shares the .btn-login class.
 		this.submitButton = page.getByRole("button", { name: "Continue" });
 		this.errorMessage = page.locator(".msgprint, .alert-danger").first();
 	}

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -16,7 +16,9 @@ export class LoginPage {
 		// Frappe login page selectors
 		this.emailInput = page.locator("#login_email");
 		this.passwordInput = page.locator("#login_password");
-		this.submitButton = page.locator("button.btn-login");
+		// Scope to the "Continue" submit button; the login page also renders a
+		// second "Send login link" button that shares the .btn-login class.
+		this.submitButton = page.getByRole("button", { name: "Continue" });
 		this.errorMessage = page.locator(".msgprint, .alert-danger").first();
 	}
 


### PR DESCRIPTION
## Problem
The **UI Tests** (Playwright) workflow has been failing on every run — 2 failed / 65 passed. Both failures are in `e2e/tests/auth.spec.ts` (`should login via UI`, `should show error for invalid credentials`).

Root cause: the Frappe login page now renders **two** buttons carrying the `.btn-login` class:
- `<button class="... btn-login">Continue</button>`
- `<button class="... btn-login btn-login-with-email-link">Send login link</button>`

So `page.locator("button.btn-login")` in `LoginPage` resolved to 2 elements and Playwright strict mode rejected the click. This is an upstream Frappe UI change, so it fails regardless of PR content (confirmed same error across runs since June 30).

## Fix
Target the submit button by role + accessible name instead of the shared class:

```ts
this.submitButton = page.getByRole("button", { name: "Continue" });
```

Robust to the class churn that caused this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)