### PR TITLE
fix: hide payment summary for free bookings (#92)

### DIFF
--- a/dashboard/src/pages/BookingDetails.vue
+++ b/dashboard/src/pages/BookingDetails.vue
@@ -25,7 +25,7 @@
 						<p class="text-sm text-yellow-700">
 							{{
 								__(
-									"Your booking is confirmed subject to verifying the offline payment details. You will be notified once payment is verified.",
+									"Your booking is confirmed subject to verifying the offline payment details. You will be notified once payment is verified."
 								)
 							}}
 						</p>
@@ -48,7 +48,7 @@
 						<p class="text-sm text-red-700">
 							{{
 								__(
-									"Your booking has been rejected. Please contact the event organizer for more information.",
+									"Your booking has been rejected. Please contact the event organizer for more information."
 								)
 							}}
 						</p>
@@ -58,9 +58,7 @@
 		</div>
 
 		<!-- Event Information and Payment Summary in two columns -->
-		<div class="grid grid-cols-1 gap-6 mb-6"
-			:class="{ 'lg:grid-cols-2': showPaymentSummary }"
-		>
+		<div class="grid grid-cols-1 gap-6 mb-6" :class="{ 'lg:grid-cols-2': showPaymentSummary }">
 			<!-- Event Information -->
 			<BookingEventInfo
 				v-if="bookingDetails.data.event"

--- a/dashboard/src/pages/BookingDetails.vue
+++ b/dashboard/src/pages/BookingDetails.vue
@@ -25,7 +25,7 @@
 						<p class="text-sm text-yellow-700">
 							{{
 								__(
-									"Your booking is confirmed subject to verifying the offline payment details. You will be notified once payment is verified."
+									"Your booking is confirmed subject to verifying the offline payment details. You will be notified once payment is verified.",
 								)
 							}}
 						</p>
@@ -48,7 +48,7 @@
 						<p class="text-sm text-red-700">
 							{{
 								__(
-									"Your booking has been rejected. Please contact the event organizer for more information."
+									"Your booking has been rejected. Please contact the event organizer for more information.",
 								)
 							}}
 						</p>
@@ -58,7 +58,9 @@
 		</div>
 
 		<!-- Event Information and Payment Summary in two columns -->
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+		<div class="grid grid-cols-1 gap-6 mb-6"
+			:class="{ 'lg:grid-cols-2': showPaymentSummary }"
+		>
 			<!-- Event Information -->
 			<BookingEventInfo
 				v-if="bookingDetails.data.event"
@@ -68,18 +70,8 @@
 
 			<!-- Booking Financial Summary -->
 			<BookingFinancialSummary
-				v-if="!bookingDetails.data.event.free_webinar && bookingDetails.data.doc"
+				v-if="!bookingDetails.data.event.free_webinar && showPaymentSummary"
 				:booking="bookingDetails.data.doc"
-			/>
-
-			<!-- Booking Financial Summary -->
-			<BookingFinancialSummary
-				v-if="
-					!bookingDetails.data.event.free_webinar &&
-					bookingDetails.data.booking_summary &&
-					!isOfflinePaymentPending
-				"
-				:summary="bookingDetails.data.booking_summary"
 			/>
 		</div>
 
@@ -148,6 +140,12 @@ const isOfflinePaymentPending = computed(() => {
 
 const isBookingRejected = computed(() => {
 	return bookingDetails.data?.doc?.status === "Rejected";
+});
+
+// Hide the payment summary for free bookings (total_amount == 0)
+const showPaymentSummary = computed(() => {
+	const doc = bookingDetails.data?.doc;
+	return doc && (doc.total_amount || 0) > 0;
 });
 
 // Check if this is a successful payment redirect (check URL immediately)


### PR DESCRIPTION
## What
Free event bookings (`total_amount == 0`) showed a Payment Summary card with ₹0.00 Subtotal / Total Paid — noise for the attendee. Closes #92.

<img width="5088" height="4970" alt="image" src="https://github.com/user-attachments/assets/38086595-bba5-404c-a647-ef25d760306b" />


## Changes
- `BookingDetails.vue`: added `showPaymentSummary` computed (`total_amount > 0`) and guard the card with it. Free-webinar path unchanged.
- Grid collapses to a single full-width column when the summary is hidden, so Event Info no longer sits in half the row.
- Removed a dead second `BookingFinancialSummary` instance — `booking_summary` is never returned by `buzz.api.get_booking_details` and the component declares no `summary` prop, so its `v-if` was always false.

## Notes
Keys off booking total, so a paid booking a coupon brought to ₹0 also hides the summary (intended).

## Test
- Free booking (#B002) → Payment Summary gone, Event Info full width.
- Paid booking (`total_amount > 0`) → summary renders as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)