### PR TITLE
fix: guest booking confirmation screen after payment (#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ buzz/www/dashboard.html
 /playwright/.cache/
 /playwright/.auth/
 /e2e/.auth/
+.playwright-mcp/
+# Local planning docs
+plans/

--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -559,10 +559,16 @@ def get_booking_confirmation(booking_id: str, token: str | None = None) -> dict:
 		fields=[
 			"name",
 			"attendee_name",
+			"attendee_email",
 			"ticket_type.title as ticket_type",
 			"qr_code",
 		],
 	)
+
+	venue = None
+	if event_doc.venue:
+		venue_doc = frappe.get_cached_doc("Event Venue", event_doc.venue)
+		venue = {"name": venue_doc.name, "address": venue_doc.get("address")}
 
 	return frappe._dict(
 		{
@@ -573,14 +579,22 @@ def get_booking_confirmation(booking_id: str, token: str | None = None) -> dict:
 				"end_date": event_doc.end_date,
 				"start_time": event_doc.start_time,
 				"end_time": event_doc.end_time,
-				"venue": event_doc.venue,
+				"short_description": event_doc.get("short_description"),
+				"free_webinar": event_doc.get("free_webinar"),
 			},
+			"venue": venue,
 			"booking": {
 				"name": booking_doc.name,
 				"total_amount": booking_doc.total_amount,
+				"net_amount": booking_doc.net_amount,
 				"currency": booking_doc.currency,
 				"payment_status": booking_doc.payment_status,
 				"status": booking_doc.status,
+				"tax_amount": booking_doc.tax_amount,
+				"tax_label": booking_doc.tax_label,
+				"tax_percentage": booking_doc.tax_percentage,
+				"discount_amount": booking_doc.discount_amount,
+				"coupon_code": booking_doc.coupon_code,
 			},
 			"tickets": tickets,
 		}

--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -537,13 +537,14 @@ def verify_booking_access_token(booking_name: str, token: str | None) -> bool:
 	return bool(token) and hmac.compare_digest(get_booking_access_token(booking_name), token)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_booking_confirmation(booking_id: str, token: str | None = None) -> dict:
 	"""Read-only booking confirmation for the post-payment success page.
 
 	Authorized by a valid access token (guest flow) OR read permission on the
 	booking (logged-in owner). Returns a minimal payload — no transfer/cancel data.
 	"""
+	# nosemgrep: frappe-semgrep-rules.rules.unchecked-frappe-permission-call -- return value checked below
 	authorized = verify_booking_access_token(booking_id, token) or frappe.has_permission(
 		"Event Booking", "read", doc=booking_id
 	)

--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -21,6 +21,7 @@ from frappe.utils import (
 	today,
 	validate_email_address,
 )
+from frappe.utils.password import get_encryption_key
 
 from buzz.payments import (
 	get_payment_gateways_for_event,
@@ -529,7 +530,7 @@ def get_booking_access_token(booking_name: str) -> str:
 	Lets a guest (whose browser session stays "Guest") open their own booking
 	confirmation without logging in, while keeping sequential booking names
 	unguessable (no IDOR)."""
-	key = frappe.local.conf.get("encryption_key").encode()
+	key = get_encryption_key().encode()
 	return hmac.new(key, booking_name.encode(), hashlib.sha256).hexdigest()
 
 

--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -1,3 +1,5 @@
+import hashlib
+import hmac
 import os
 from base64 import b32encode
 
@@ -515,10 +517,74 @@ def process_booking(
 	return {
 		"payment_link": get_payment_link_for_booking(
 			booking.name,
-			redirect_to=f"/dashboard/bookings/{booking.name}?success=true",
+			redirect_to=f"/dashboard/booking-success/{booking.name}?token={get_booking_access_token(booking.name)}",
 			payment_gateway=payment_gateway,
 		)
 	}
+
+
+def get_booking_access_token(booking_name: str) -> str:
+	"""HMAC of the booking name signed with the site encryption_key.
+
+	Lets a guest (whose browser session stays "Guest") open their own booking
+	confirmation without logging in, while keeping sequential booking names
+	unguessable (no IDOR)."""
+	key = frappe.local.conf.get("encryption_key").encode()
+	return hmac.new(key, booking_name.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_booking_access_token(booking_name: str, token: str | None) -> bool:
+	return bool(token) and hmac.compare_digest(get_booking_access_token(booking_name), token)
+
+
+@frappe.whitelist(allow_guest=True)
+def get_booking_confirmation(booking_id: str, token: str | None = None) -> dict:
+	"""Read-only booking confirmation for the post-payment success page.
+
+	Authorized by a valid access token (guest flow) OR read permission on the
+	booking (logged-in owner). Returns a minimal payload — no transfer/cancel data.
+	"""
+	authorized = verify_booking_access_token(booking_id, token) or frappe.has_permission(
+		"Event Booking", "read", doc=booking_id
+	)
+	if not authorized:
+		frappe.throw(_("You are not allowed to view this booking."), frappe.PermissionError)
+
+	booking_doc = frappe.get_cached_doc("Event Booking", booking_id)
+	event_doc = frappe.get_cached_doc("Buzz Event", booking_doc.event)
+
+	tickets = frappe.db.get_all(
+		"Event Ticket",
+		filters={"booking": booking_id},
+		fields=[
+			"name",
+			"attendee_name",
+			"ticket_type.title as ticket_type",
+			"qr_code",
+		],
+	)
+
+	return frappe._dict(
+		{
+			"event": {
+				"title": event_doc.title,
+				"route": event_doc.route,
+				"start_date": event_doc.start_date,
+				"end_date": event_doc.end_date,
+				"start_time": event_doc.start_time,
+				"end_time": event_doc.end_time,
+				"venue": event_doc.venue,
+			},
+			"booking": {
+				"name": booking_doc.name,
+				"total_amount": booking_doc.total_amount,
+				"currency": booking_doc.currency,
+				"payment_status": booking_doc.payment_status,
+				"status": booking_doc.status,
+			},
+			"tickets": tickets,
+		}
+	)
 
 
 def create_add_on_doc(attendee_name: str, add_ons: list[dict]):

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1091,3 +1091,87 @@ class TestProcessBookingAPI(IntegrationTestCase):
 		self.assertEqual(booking.status, "Confirmed", "Free booking should auto-confirm")
 		self.assertEqual(booking.payment_status, "Paid", "Free booking should be marked as Paid")
 		self.assertEqual(booking.total_amount, 0, "Free booking should have zero total")
+
+
+class TestBookingConfirmation(IntegrationTestCase):
+	"""Test token-gated guest booking confirmation (issue #167)."""
+
+	def _make_submitted_booking(self):
+		test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		test_event.apply_tax = False
+		test_event.save()
+
+		ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": test_event.name,
+				"title": "Confirmation Test Ticket",
+				"price": 500,
+			}
+		).insert()
+
+		booking = frappe.get_doc(
+			{
+				"doctype": "Event Booking",
+				"event": test_event.name,
+				"user": "Administrator",
+				"attendees": [
+					{"ticket_type": ticket_type.name, "first_name": "Conf", "email": "conf@email.com"}
+				],
+			}
+		).insert()
+		booking.submit()
+		return booking
+
+	def test_access_token_roundtrip(self):
+		from buzz.api import get_booking_access_token, verify_booking_access_token
+
+		token = get_booking_access_token("B-TEST-001")
+		self.assertTrue(verify_booking_access_token("B-TEST-001", token))
+		# wrong token rejected
+		self.assertFalse(verify_booking_access_token("B-TEST-001", "deadbeef"))
+		# empty token rejected
+		self.assertFalse(verify_booking_access_token("B-TEST-001", ""))
+		self.assertFalse(verify_booking_access_token("B-TEST-001", None))
+		# token is booking-specific
+		self.assertFalse(verify_booking_access_token("B-OTHER-002", token))
+
+	def test_get_booking_confirmation_valid_token_as_guest(self):
+		from buzz.api import get_booking_access_token, get_booking_confirmation
+
+		booking = self._make_submitted_booking()
+		token = get_booking_access_token(booking.name)
+
+		frappe.set_user("Guest")
+		try:
+			result = get_booking_confirmation(booking.name, token=token)
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertEqual(result["booking"]["name"], booking.name)
+		self.assertEqual(len(result["tickets"]), 1)
+		self.assertEqual(result["tickets"][0]["attendee_name"], "Conf")
+		self.assertTrue(result["event"]["title"])
+
+	def test_get_booking_confirmation_bad_token_as_guest_raises(self):
+		from buzz.api import get_booking_confirmation
+
+		booking = self._make_submitted_booking()
+
+		frappe.set_user("Guest")
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				get_booking_confirmation(booking.name, token="wrong-token")
+			with self.assertRaises(frappe.PermissionError):
+				get_booking_confirmation(booking.name, token="")
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_get_booking_confirmation_owner_without_token(self):
+		from buzz.api import get_booking_confirmation
+
+		booking = self._make_submitted_booking()
+
+		# Administrator owns/has perm — no token needed
+		result = get_booking_confirmation(booking.name)
+		self.assertEqual(result["booking"]["name"], booking.name)

--- a/dashboard/src/pages/BookingSuccess.vue
+++ b/dashboard/src/pages/BookingSuccess.vue
@@ -1,0 +1,101 @@
+<template>
+	<div class="w-4" v-if="confirmation.loading">
+		<Spinner />
+	</div>
+
+	<div v-else-if="confirmation.data">
+		<!-- Success message + confetti -->
+		<SuccessMessage
+			:show="showSuccessMessage"
+			:is-webinar="confirmation.data.event.free_webinar"
+		/>
+
+		<!-- Event Information and Payment Summary in two columns -->
+		<div class="grid grid-cols-1 gap-6 mb-6" :class="{ 'lg:grid-cols-2': showPaymentSummary }">
+			<BookingEventInfo :event="confirmation.data.event" :venue="confirmation.data.venue" />
+
+			<BookingFinancialSummary
+				v-if="showPaymentSummary"
+				:booking="confirmation.data.booking"
+			/>
+		</div>
+
+		<!-- Tickets (read-only) -->
+		<TicketsSection
+			:tickets="confirmation.data.tickets"
+			:can-request-cancellation="false"
+			:can-transfer-tickets="false"
+			:can-change-add-ons="false"
+		/>
+
+		<!-- Manage bookings CTA -->
+		<div class="mt-6 flex justify-center">
+			<Button v-if="!session.isLoggedIn" variant="outline" @click="openLoginDialog()">
+				{{ __("Log in to manage bookings") }}
+			</Button>
+			<Button v-else variant="outline" :link="`/dashboard/account/bookings/${bookingId}`">
+				{{ __("Manage booking") }}
+			</Button>
+		</div>
+	</div>
+
+	<!-- Error / invalid token -->
+	<div v-else-if="confirmation.error" class="text-center py-16">
+		<h2 class="text-xl font-semibold text-ink-gray-9 mb-2">
+			{{ __("Booking not found") }}
+		</h2>
+		<p class="text-ink-gray-6">
+			{{ __("This confirmation link is invalid or has expired.") }}
+		</p>
+	</div>
+</template>
+
+<script setup>
+import { useBookingFormStorage } from "@/composables/useBookingFormStorage";
+import { useLoginDialog } from "@/composables/useLoginDialog";
+import { usePaymentSuccess } from "@/composables/usePaymentSuccess";
+import { session } from "@/data/session";
+import { Button, Spinner, createResource } from "frappe-ui";
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import BookingEventInfo from "../components/BookingEventInfo.vue";
+import BookingFinancialSummary from "../components/BookingFinancialSummary.vue";
+import SuccessMessage from "../components/SuccessMessage.vue";
+import TicketsSection from "../components/TicketsSection.vue";
+
+const props = defineProps({
+	bookingId: {
+		type: String,
+		required: true,
+	},
+});
+
+const route = useRoute();
+const { open: openLoginDialog } = useLoginDialog();
+
+// Confetti + success message, always on for this page. Keep the token in the
+// URL (cleanupUrl: false) so a refresh can still re-fetch the booking.
+const { showSuccessMessage, showSuccess } = usePaymentSuccess({
+	enableConfetti: true,
+	cleanupUrl: false,
+});
+
+const showPaymentSummary = computed(() => {
+	const booking = confirmation.data?.booking;
+	return booking && (booking.total_amount || 0) > 0;
+});
+
+const confirmation = createResource({
+	url: "buzz.api.get_booking_confirmation",
+	params: { booking_id: props.bookingId, token: route.query.token },
+	auto: true,
+	onSuccess: (data) => {
+		showSuccess();
+		// Clear any stored booking form data now that the booking is confirmed
+		if (data?.event?.route) {
+			const { clearStoredData } = useBookingFormStorage(data.event.route);
+			clearStoredData();
+		}
+	},
+});
+</script>

--- a/dashboard/src/pages/BookingSuccess.vue
+++ b/dashboard/src/pages/BookingSuccess.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="w-4" v-if="confirmation.loading">
+	<div class="flex justify-center items-center py-8" v-if="confirmation.loading">
 		<Spinner />
 	</div>
 

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -27,6 +27,13 @@ const routes: RouteRecordRaw[] = [
 		component: () => import("@/pages/EventProposalForm.vue"),
 	},
 	{
+		path: "/booking-success/:bookingId",
+		name: "booking-success",
+		props: true,
+		meta: { isPublic: true },
+		component: () => import("@/pages/BookingSuccess.vue"),
+	},
+	{
 		path: "/events/:eventRoute/forms/:formRoute",
 		props: true,
 		name: "custom-form",


### PR DESCRIPTION
## Problem

After a guest (not logged in) completes Razorpay payment, they land on a **login wall** instead of a ticket confirmation. `process_booking` redirected both guest and logged-in users to `/dashboard/bookings/{name}`, which the router rewrites to the auth-gated `/dashboard/account/bookings/{name}`. A guest's browser session stays `Guest` (shadow user is server-side only), so they fail the guard. Fixes #167.

## Approach

One **public** success route backed by a **token-gated** confirmation API. The token is an HMAC of the booking name signed with the site `encryption_key` — no schema change, no stored field, unguessable (booking names are sequential `B-###`, so opening the API outright would be an IDOR risk).

### Backend
- `get_booking_access_token` / `verify_booking_access_token` — stdlib `hmac`, constant-time compare.
- `get_booking_confirmation(booking_id, token)` — `@frappe.whitelist(allow_guest=True)`. Authorized by a valid token **or** read permission on the booking. Returns a minimal read-only payload (event, venue, financial summary, tickets + QR).
- `process_booking` redirect → `/dashboard/booking-success/{name}?token=…` for both user types.

### Frontend
- New public route `/booking-success/:bookingId` (`meta.isPublic`) bypassing the account Layout guard.
- `BookingSuccess.vue` — reuses `BookingEventInfo`, `BookingFinancialSummary`, `TicketsSection` (read-only). Confetti + success message. "Log in to manage bookings" CTA for guests; "Manage booking" link when logged in.

## Testing
- **Backend:** 4 new unit tests (token roundtrip, guest valid/bad/empty token, owner without token) — all pass.
- **E2E (manual, Playwright):** guest paid booking through the Razorpay test gateway → lands on `/dashboard/booking-success/…` with confetti, payment summary, QR tickets, and login CTA. **No login wall.** 0 console errors.

Payment redirect chain confirmed: `razorpay_checkout` → mock bank success → frappe/payments `/payment-success?redirect_to=…` → the new SPA page. `on_payment_authorized` submits the booking + generates tickets server-side before the browser reaches the page, so tickets exist on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)