### PR TITLE
ci: run workflows on merge_group for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 concurrency:
-  group: main-buzz-${{ github.event.number }}
+  group: main-buzz-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "dashboard/**"
       - ".github/workflows/typecheck.yml"
+  merge_group:
 
 concurrency:
   group: typecheck-buzz-${{ github.event.number || github.sha }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What

Add `merge_group:` trigger to **CI**, **Linters**, **Dashboard TypeScript**, and **UI Tests** workflows.

## Why

Prep for enabling the GitHub **merge queue** on `main`. The queue runs required status checks on the `merge_group` event, not `pull_request`. Without this trigger, requiring these checks in the queue would leave every PR stuck — the checks would never run.

## Changes

- `ci.yml`, `linter.yml`, `typecheck.yml`, `ui-tests.yml`: add `merge_group:` trigger
- `ci.yml`: concurrency group now falls back to `github.sha` (`merge_group` events have empty `github.event.number`, so all queued CI runs would otherwise collide in one group and cancel each other — others already had this fallback)

## Not included

Ruleset / merge-queue enablement itself (UI/settings change) — separate step, done after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)