### PR TITLE
fix: route free bookings to the booking-success confirmation screen

### DIFF
--- a/buzz/api/__init__.py
+++ b/buzz/api/__init__.py
@@ -478,7 +478,10 @@ def process_booking(
 	if booking.total_amount == 0:
 		booking.flags.ignore_permissions = True
 		booking.submit()
-		return {"booking_name": booking.name}
+		return {
+			"booking_name": booking.name,
+			"redirect_to": f"/booking-success/{booking.name}?token={get_booking_access_token(booking.name)}",
+		}
 
 	if is_offline:
 		method_filters = {"event": event, "enabled": 1}

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -940,6 +940,45 @@ class TestProcessBookingAPI(IntegrationTestCase):
 		tickets = frappe.db.get_all("Event Ticket", filters={"booking": booking.name})
 		self.assertEqual(len(tickets), 1)
 
+	def test_process_booking_free_event_returns_redirect_to(self):
+		"""Free bookings (total_amount == 0) must get a redirect_to the new
+		token-gated booking-success screen, same as the paid-gateway branch."""
+		from buzz.api import process_booking, verify_booking_access_token
+
+		test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		test_event.apply_tax = False
+		test_event.is_published = True
+		test_event.save()
+
+		free_ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": test_event.name,
+				"title": "Free Redirect Test Ticket",
+				"price": 0,
+				"is_published": True,
+			}
+		).insert()
+
+		result = process_booking(
+			attendees=[
+				{
+					"first_name": "Redirect Test User",
+					"email": "redirecttest@email.com",
+					"ticket_type": str(free_ticket_type.name),
+					"add_ons": [],
+				}
+			],
+			event=str(test_event.name),
+		)
+
+		self.assertIn("booking_name", result)
+		self.assertIn("redirect_to", result)
+		self.assertTrue(result["redirect_to"].startswith(f"/booking-success/{result['booking_name']}?token="))
+
+		token = result["redirect_to"].split("token=")[1]
+		self.assertTrue(verify_booking_access_token(result["booking_name"], token))
+
 	def test_process_booking_without_utm_parameters(self):
 		"""Test that process_booking API works without UTM parameters."""
 		from buzz.api import process_booking

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -407,6 +407,7 @@
 import { useBookingFormStorage } from "@/composables/useBookingFormStorage";
 import { useLoginDialog } from "@/composables/useLoginDialog";
 import { userResource } from "@/data/user";
+import { resolveBookingSuccessAction } from "@/utils/bookingSuccessRedirect";
 import { formatCurrency, formatPriceOrFree } from "@/utils/currency";
 import { clearBookingCache } from "@/utils/index";
 import BillingDetails from "@/components/BillingDetails.vue";
@@ -1274,17 +1275,17 @@ function submitBooking(payload, paymentGateway, { isOtpFlow = false } = {}) {
 					clearOtpState();
 				}
 
-				if (data.payment_link) {
-					window.location.href = data.payment_link;
-				} else if (props.isGuestMode) {
+				const action = resolveBookingSuccessAction(data, {
+					isGuestMode: props.isGuestMode,
+				});
+
+				if (action.type === "external") {
+					window.location.href = action.url;
+				} else if (action.type === "guest-inline") {
 					bookingSuccess.value = true;
-					successBookingName.value = data.booking_name;
-				} else if (data.offline_payment) {
-					// Offline payment submitted - redirect to booking details
-					router.replace(`/bookings/${data.booking_name}?success=true&offline=true`);
+					successBookingName.value = action.bookingName;
 				} else {
-					// free event
-					router.replace(`/bookings/${data.booking_name}?success=true`);
+					router.replace(action.path);
 				}
 			},
 			onError: (error) => {

--- a/dashboard/src/pages/BookingSuccess.vue
+++ b/dashboard/src/pages/BookingSuccess.vue
@@ -10,6 +10,14 @@
 			:is-webinar="confirmation.data.event.free_webinar"
 		/>
 
+		<h2 class="text-3xl font-bold text-ink-gray-9 mb-4">
+			{{
+				confirmation.data.event.free_webinar
+					? __("Registration Confirmed")
+					: __("Booking Confirmed")
+			}}
+		</h2>
+
 		<!-- Event Information and Payment Summary in two columns -->
 		<div class="grid grid-cols-1 gap-6 mb-6" :class="{ 'lg:grid-cols-2': showPaymentSummary }">
 			<BookingEventInfo :event="confirmation.data.event" :venue="confirmation.data.venue" />

--- a/dashboard/src/utils/bookingSuccessRedirect.js
+++ b/dashboard/src/utils/bookingSuccessRedirect.js
@@ -1,0 +1,19 @@
+export function resolveBookingSuccessAction(data, { isGuestMode }) {
+	if (data.payment_link) {
+		return { type: "external", url: data.payment_link };
+	}
+
+	if (data.redirect_to) {
+		return { type: "route", path: data.redirect_to };
+	}
+
+	if (isGuestMode) {
+		return { type: "guest-inline", bookingName: data.booking_name };
+	}
+
+	if (data.offline_payment) {
+		return { type: "route", path: `/bookings/${data.booking_name}?success=true&offline=true` };
+	}
+
+	return { type: "route", path: `/bookings/${data.booking_name}?success=true` };
+}

--- a/dashboard/src/utils/bookingSuccessRedirect.test.js
+++ b/dashboard/src/utils/bookingSuccessRedirect.test.js
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveBookingSuccessAction } from "./bookingSuccessRedirect.js";
+
+test("payment_link takes priority and is external", () => {
+	const action = resolveBookingSuccessAction(
+		{ payment_link: "https://gateway.example/pay/123" },
+		{ isGuestMode: true }
+	);
+	assert.deepEqual(action, { type: "external", url: "https://gateway.example/pay/123" });
+});
+
+test("redirect_to routes to booking-success for a guest", () => {
+	const action = resolveBookingSuccessAction(
+		{ booking_name: "B-0001", redirect_to: "/booking-success/B-0001?token=abc" },
+		{ isGuestMode: true }
+	);
+	assert.deepEqual(action, { type: "route", path: "/booking-success/B-0001?token=abc" });
+});
+
+test("redirect_to routes to booking-success for a logged-in user", () => {
+	const action = resolveBookingSuccessAction(
+		{ booking_name: "B-0002", redirect_to: "/booking-success/B-0002?token=def" },
+		{ isGuestMode: false }
+	);
+	assert.deepEqual(action, { type: "route", path: "/booking-success/B-0002?token=def" });
+});
+
+test("guest with no redirect_to and no payment_link falls back to inline confirmation", () => {
+	const action = resolveBookingSuccessAction({ booking_name: "B-0003" }, { isGuestMode: true });
+	assert.deepEqual(action, { type: "guest-inline", bookingName: "B-0003" });
+});
+
+test("logged-in offline booking routes to bookings page with offline flag", () => {
+	const action = resolveBookingSuccessAction(
+		{ booking_name: "B-0004", offline_payment: true },
+		{ isGuestMode: false }
+	);
+	assert.deepEqual(action, {
+		type: "route",
+		path: "/bookings/B-0004?success=true&offline=true",
+	});
+});
+
+test("logged-in booking with none of the above falls back to bookings page", () => {
+	const action = resolveBookingSuccessAction({ booking_name: "B-0005" }, { isGuestMode: false });
+	assert.deepEqual(action, { type: "route", path: "/bookings/B-0005?success=true" });
+});

--- a/e2e/tests/guest-booking.spec.ts
+++ b/e2e/tests/guest-booking.spec.ts
@@ -35,7 +35,7 @@ test.describe("Guest Booking", () => {
 
 		await bookingPage.submit();
 
-		await expect(page.getByText("Booking Confirmed!")).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText("Booking Confirmed")).toBeVisible({ timeout: 30000 });
 	});
 
 	test("guest booking with Email OTP", async ({ page }) => {
@@ -65,7 +65,7 @@ test.describe("Guest Booking", () => {
 		await page.locator('input[placeholder="123456"]').fill(otp!);
 		await page.getByRole("button", { name: "Verify & Book" }).click();
 
-		await expect(page.getByText("Booking Confirmed!")).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText("Booking Confirmed")).toBeVisible({ timeout: 30000 });
 	});
 
 	test("guest booking with Phone OTP", async ({ page }) => {
@@ -97,6 +97,6 @@ test.describe("Guest Booking", () => {
 		await page.locator('input[placeholder="123456"]').fill(otp!);
 		await page.getByRole("button", { name: "Verify & Book" }).click();
 
-		await expect(page.getByText("Booking Confirmed!")).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText("Booking Confirmed")).toBeVisible({ timeout: 30000 });
 	});
 });


### PR DESCRIPTION
While taking a look at #255 , i noticed that after booking, we were not routing users to the newly created success page. That was because we did not handle it for free events in #259 . This PR fixes for that

## Summary
- Free bookings (total_amount == 0, incl. 100%-off coupon) landed on the old inline "Booking Confirmed!" card for guests, or the BookingDetails page for logged-in users, instead of the new `BookingSuccess.vue` screen paid bookings reach.
- Root cause: `process_booking`'s free-total branch returned only `{booking_name}`, no `redirect_to`/token, unlike the paid-gateway branch.
- Backend now returns `redirect_to` for free bookings, same token-gated `booking-success` URL as paid bookings.
- Frontend routing decision extracted into a pure `resolveBookingSuccessAction()` (unit tested) and wired into `BookingForm.vue`.

## Test plan
- [x] `bench --site buzz.localhost run-tests --module buzz.ticketing.doctype.event_booking.test_event_booking` — 28 passed
- [x] `yarn test:unit` (dashboard) — 20 passed
- [x] Manual: guest booking on a free (100%-coupon) event via `agent-browser` now lands on `/booking-success/:id?token=...` showing tickets + QR, not the old card

🤖 Generated with [Claude Code](https://claude.com/claude-code)