### PR TITLE
fix(proposals): make Event Proposal start and end time mandatory (#223)

### DIFF
--- a/buzz/proposals/doctype/event_proposal/event_proposal.json
+++ b/buzz/proposals/doctype/event_proposal/event_proposal.json
@@ -121,12 +121,14 @@
   {
    "fieldname": "start_time",
    "fieldtype": "Time",
-   "label": "Start Time"
+   "label": "Start Time",
+   "reqd": 1
   },
   {
    "fieldname": "end_time",
    "fieldtype": "Time",
-   "label": "End Time"
+   "label": "End Time",
+   "reqd": 1
   },
   {
    "fieldname": "about",

--- a/buzz/proposals/doctype/event_proposal/test_event_proposal.py
+++ b/buzz/proposals/doctype/event_proposal/test_event_proposal.py
@@ -126,6 +126,20 @@ class IntegrationTestEventProposal(IntegrationTestCase):
 		self.assertTrue(frappe.db.exists("Event Host", company))
 		self.assertEqual(proposal.status, "Event Created")
 
+	def test_start_and_end_time_are_mandatory(self):
+		proposal = frappe.new_doc("Event Proposal")
+		proposal.update(
+			{
+				"title": f"Proposal {frappe.generate_hash(length=6)}",
+				"category": self.category,
+				"medium": "Online",
+				"start_date": "2030-01-01",
+				"about": "<p>About the event</p>",
+			}
+		)
+		with self.assertRaises(frappe.MandatoryError):
+			proposal.insert(ignore_permissions=True)
+
 	def test_submit_without_host_or_company_throws(self):
 		proposal = self.make_proposal(status="Approved")
 		with self.assertRaises(frappe.ValidationError):


### PR DESCRIPTION
Fixes #223 (reported upstream at buildwithhussain/buzz#223)

## Problem

Event Proposal left Start Time / End Time optional, but Buzz Event requires both. Submitting an approved proposal without times failed inside `create_event` with a cryptic error about a different doctype:

```
MandatoryError: [Buzz Event, ...]: start_time, end_time
```

## Fix

Mark `start_time` and `end_time` as `reqd` on Event Proposal. Times are collected upfront where the proposer knows them; Desk and the portal proposal form both mirror the `reqd` flag (`get_form_fields` in `buzz/api/forms.py`), so no frontend change needed. Existing `validate_times` ordering check keeps its empty-guard since `validate()` runs before mandatory checks.

## Tests

- New regression test: insert without times raises `MandatoryError` (written first, watched fail, then fixed)
- `test_event_proposal` module: 9 passed
- `buzz.api.test_forms`: 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)