### PR TITLE
feat(ticketing): send booking confirmation email to the booker (#56)

### DIFF
--- a/buzz/events/doctype/buzz_event/buzz_event.json
+++ b/buzz/events/doctype/buzz_event/buzz_event.json
@@ -71,6 +71,9 @@
   "column_break_ukql",
   "attach_email_ticket",
   "ticket_print_format",
+  "booking_confirmation_email_section",
+  "send_booking_confirmation_email",
+  "booking_confirmation_email_template",
   "talks_section",
   "allow_editing_talks_after_acceptance",
   "custom_forms_tab",
@@ -269,6 +272,25 @@
    "fieldname": "ticket_email_template",
    "fieldtype": "Link",
    "label": "Ticket Email Template",
+   "options": "Email Template"
+  },
+  {
+   "fieldname": "booking_confirmation_email_section",
+   "fieldtype": "Section Break",
+   "label": "Booking Confirmation Email"
+  },
+  {
+   "default": "1",
+   "description": "Send a confirmation email with a booking summary to the person who made the booking.",
+   "fieldname": "send_booking_confirmation_email",
+   "fieldtype": "Check",
+   "label": "Send Booking Confirmation Email"
+  },
+  {
+   "depends_on": "eval:doc.send_booking_confirmation_email;",
+   "fieldname": "booking_confirmation_email_template",
+   "fieldtype": "Link",
+   "label": "Booking Confirmation Email Template",
    "options": "Email Template"
   },
   {

--- a/buzz/events/doctype/buzz_settings/buzz_settings.json
+++ b/buzz/events/doctype/buzz_settings/buzz_settings.json
@@ -28,6 +28,7 @@
   "communications_tab",
   "ticketing_emails_section",
   "default_ticket_email_template",
+  "default_booking_confirmation_email_template",
   "sponsorship_emails_section",
   "auto_send_pitch_deck",
   "sponsor_email_settings_section",
@@ -157,6 +158,13 @@
    "fieldname": "default_ticket_email_template",
    "fieldtype": "Link",
    "label": "Default Ticket Email Template",
+   "options": "Email Template"
+  },
+  {
+   "description": "Default template for booking confirmation emails sent to the booker. Can be overridden per event.",
+   "fieldname": "default_booking_confirmation_email_template",
+   "fieldtype": "Link",
+   "label": "Default Booking Confirmation Email Template",
    "options": "Email Template"
   },
   {

--- a/buzz/templates/emails/booking_confirmation.html
+++ b/buzz/templates/emails/booking_confirmation.html
@@ -201,6 +201,7 @@
             </table>
 
             <!-- Note about tickets -->
+            {% if event_doc.send_ticket_email %}
             <table
               align="center"
               width="100%"
@@ -219,6 +220,7 @@
                 </tr>
               </tbody>
             </table>
+            {% endif %}
 
             {% set event_settings = frappe.get_cached_doc("Buzz Settings") %}
             {% if event_settings.support_email %}

--- a/buzz/templates/emails/booking_confirmation.html
+++ b/buzz/templates/emails/booking_confirmation.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+  </head>
+  <body
+    style='background-color:rgb(243,244,246);font-family:ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";padding-top:40px;padding-bottom:40px'>
+    <div
+      style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
+      data-skip-in-text="true">
+      Your booking for {{ event_title }} is confirmed.
+    </div>
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="background-color:rgb(255,255,255);border-radius:8px;max-width:600px;margin-left:auto;margin-right:auto;overflow:hidden">
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <!-- Header -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="background-color:rgb(31,41,55);padding-left:40px;padding-right:40px;padding-top:32px;padding-bottom:32px;text-align:center">
+              <tbody>
+                <tr>
+                  <td>
+                    <h1
+                      style="color:rgb(255,255,255);font-size:28px;font-weight:700;margin:0px;margin-bottom:8px">
+                      ✅ Booking Confirmed
+                    </h1>
+                    <p
+                      style="color:rgb(219,234,254);font-size:16px;margin:0px;line-height:24px">
+                      Thanks for booking. Here's your summary.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Event + booking meta -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:32px;padding-bottom:8px">
+              <tbody>
+                <tr>
+                  <td>
+                    <h2
+                      style="color:rgb(31,41,55);font-size:22px;font-weight:700;margin:0px;margin-bottom:8px">
+                      {{ event_title }}
+                    </h2>
+                    <p
+                      style="color:rgb(75,85,99);font-size:14px;margin:0px;line-height:22px">
+                      📅 {{ frappe.format_date(event_doc.start_date) }}
+                      {% if event_doc.start_date != event_doc.end_date %}
+                        - {{ frappe.format_date(event_doc.end_date) }}
+                      {% endif %}
+                      {% if venue %}&nbsp;&nbsp;·&nbsp;&nbsp;📍 {{ venue }}{% endif %}
+                    </p>
+                    <p
+                      style="color:rgb(75,85,99);font-size:14px;margin-top:12px;margin-bottom:0px;line-height:22px">
+                      Booking ID:
+                      <span style='font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;color:rgb(31,41,55);font-weight:600'>{{ doc.name }}</span>
+                      &nbsp;&nbsp;·&nbsp;&nbsp;Payment: <strong>{{ doc.payment_status }}</strong>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Attendees / tickets -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:16px;padding-bottom:8px">
+              <tbody>
+                <tr>
+                  <td>
+                    <p
+                      style="color:rgb(75,85,99);font-size:13px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin:0px;margin-bottom:8px">
+                      Tickets ({{ doc.attendees | length }})
+                    </p>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="border-top:1px solid rgb(229,231,235)">
+                      <tbody>
+                        {% for attendee in doc.attendees %}
+                        <tr>
+                          <td
+                            style="padding-top:12px;padding-bottom:12px;border-bottom:1px solid rgb(229,231,235);vertical-align:top">
+                            <p
+                              style="color:rgb(31,41,55);font-size:15px;font-weight:600;margin:0px;line-height:20px">
+                              {{ attendee.full_name or [attendee.first_name, attendee.last_name] | select | join(" ") }}
+                            </p>
+                            <p
+                              style="color:rgb(107,114,128);font-size:13px;margin:2px 0px 0px 0px;line-height:18px">
+                              {{ frappe.db.get_value("Event Ticket Type", attendee.ticket_type, "title") }}
+                              {% if attendee.number_of_add_ons %}
+                                &nbsp;·&nbsp; {{ attendee.number_of_add_ons }} add-on(s)
+                              {% endif %}
+                            </p>
+                          </td>
+                          <td
+                            style="padding-top:12px;padding-bottom:12px;border-bottom:1px solid rgb(229,231,235);text-align:right;vertical-align:top;white-space:nowrap">
+                            <p
+                              style="color:rgb(31,41,55);font-size:15px;font-weight:500;margin:0px;line-height:20px">
+                              {{ frappe.utils.fmt_money(attendee.amount + (attendee.add_on_total or 0), currency=doc.currency) }}
+                            </p>
+                          </td>
+                        </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Totals -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:8px;padding-bottom:24px">
+              <tbody>
+                <tr>
+                  <td>
+                    <table
+                      align="right"
+                      width="60%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation">
+                      <tbody>
+                        <tr>
+                          <td style="padding:4px 0px;color:rgb(75,85,99);font-size:14px">Subtotal</td>
+                          <td style="padding:4px 0px;color:rgb(31,41,55);font-size:14px;text-align:right">
+                            {{ frappe.utils.fmt_money(doc.net_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                        {% if doc.discount_amount %}
+                        <tr>
+                          <td style="padding:4px 0px;color:rgb(22,163,74);font-size:14px">
+                            Discount{% if doc.coupon_code %} ({{ doc.coupon_code }}){% endif %}
+                          </td>
+                          <td style="padding:4px 0px;color:rgb(22,163,74);font-size:14px;text-align:right">
+                            &minus; {{ frappe.utils.fmt_money(doc.discount_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                        {% endif %}
+                        {% if doc.tax_amount %}
+                        <tr>
+                          <td style="padding:4px 0px;color:rgb(75,85,99);font-size:14px">
+                            {{ doc.tax_label or "Tax" }}{% if doc.tax_percentage %} ({{ doc.tax_percentage }}%){% endif %}
+                          </td>
+                          <td style="padding:4px 0px;color:rgb(31,41,55);font-size:14px;text-align:right">
+                            {{ frappe.utils.fmt_money(doc.tax_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                        {% endif %}
+                        <tr>
+                          <td style="padding:10px 0px 0px 0px;border-top:2px solid rgb(229,231,235);color:rgb(31,41,55);font-size:16px;font-weight:700">
+                            Total
+                          </td>
+                          <td style="padding:10px 0px 0px 0px;border-top:2px solid rgb(229,231,235);color:rgb(31,41,55);font-size:16px;font-weight:700;text-align:right">
+                            {{ frappe.utils.fmt_money(doc.total_amount, currency=doc.currency) }}
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Note about tickets -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="background-color:rgb(249,250,251);padding-left:40px;padding-right:40px;padding-top:20px;padding-bottom:20px;text-align:center;border-top:1px solid rgb(229,231,235)">
+              <tbody>
+                <tr>
+                  <td>
+                    <p style="color:rgb(75,85,99);font-size:14px;margin:0px;line-height:22px">
+                      🎟️ Individual tickets with entry QR codes have been emailed to each attendee.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            {% set event_settings = frappe.get_cached_doc("Buzz Settings") %}
+            {% if event_settings.support_email %}
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="padding-left:40px;padding-right:40px;padding-top:20px;padding-bottom:20px;text-align:center">
+              <tbody>
+                <tr>
+                  <td>
+                    <p style="color:rgb(75,85,99);font-size:14px;margin:0px;margin-bottom:12px;line-height:22px">
+                      Need help? Contact our support team.
+                    </p>
+                    <a
+                      href="mailto:{{ event_settings.support_email }}"
+                      style="background-color:rgb(37,99,235);color:rgb(255,255,255);padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;text-decoration-line:none"
+                      target="_blank">Contact Support</a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            {% endif %}
+
+            <!-- Footer -->
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="background-color:rgb(31,41,55);padding-left:40px;padding-right:40px;padding-top:24px;padding-bottom:24px;text-align:center">
+              <tbody>
+                <tr>
+                  <td>
+                    <p style="color:rgb(209,213,219);font-size:14px;margin:0px;line-height:22px">
+                      Powered by <a href="https://github.com/BuildWithHussain/buzz" style="color:rgb(209,213,219)">Buzz</a>. Built on <a href="https://frappe.io/framework" style="color:rgb(209,213,219)">Frappe Framework</a>.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/buzz/templates/emails/booking_confirmation.html
+++ b/buzz/templates/emails/booking_confirmation.html
@@ -96,7 +96,7 @@
                   <td>
                     <p
                       style="color:rgb(75,85,99);font-size:13px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin:0px;margin-bottom:8px">
-                      Tickets ({{ doc.attendees | length }})
+                      Tickets ({{ attendee_rows | length }})
                     </p>
                     <table
                       align="center"
@@ -107,17 +107,17 @@
                       role="presentation"
                       style="border-top:1px solid rgb(229,231,235)">
                       <tbody>
-                        {% for attendee in doc.attendees %}
+                        {% for attendee in attendee_rows %}
                         <tr>
                           <td
                             style="padding-top:12px;padding-bottom:12px;border-bottom:1px solid rgb(229,231,235);vertical-align:top">
                             <p
                               style="color:rgb(31,41,55);font-size:15px;font-weight:600;margin:0px;line-height:20px">
-                              {{ attendee.full_name or [attendee.first_name, attendee.last_name] | select | join(" ") }}
+                              {{ attendee.full_name }}
                             </p>
                             <p
                               style="color:rgb(107,114,128);font-size:13px;margin:2px 0px 0px 0px;line-height:18px">
-                              {{ frappe.db.get_value("Event Ticket Type", attendee.ticket_type, "title") }}
+                              {{ attendee.ticket_type_title }}
                               {% if attendee.number_of_add_ons %}
                                 &nbsp;·&nbsp; {{ attendee.number_of_add_ons }} add-on(s)
                               {% endif %}
@@ -127,7 +127,7 @@
                             style="padding-top:12px;padding-bottom:12px;border-bottom:1px solid rgb(229,231,235);text-align:right;vertical-align:top;white-space:nowrap">
                             <p
                               style="color:rgb(31,41,55);font-size:15px;font-weight:500;margin:0px;line-height:20px">
-                              {{ frappe.utils.fmt_money(attendee.amount + (attendee.add_on_total or 0), currency=doc.currency) }}
+                              {{ frappe.utils.fmt_money(attendee.amount, currency=doc.currency) }}
                             </p>
                           </td>
                         </tr>

--- a/buzz/templates/emails/booking_confirmation.html
+++ b/buzz/templates/emails/booking_confirmation.html
@@ -222,8 +222,7 @@
             </table>
             {% endif %}
 
-            {% set event_settings = frappe.get_cached_doc("Buzz Settings") %}
-            {% if event_settings.support_email %}
+            {% if support_email %}
             <table
               align="center"
               width="100%"
@@ -239,7 +238,7 @@
                       Need help? Contact our support team.
                     </p>
                     <a
-                      href="mailto:{{ event_settings.support_email }}"
+                      href="mailto:{{ support_email }}"
                       style="background-color:rgb(37,99,235);color:rgb(255,255,255);padding:12px 24px;border-radius:6px;font-size:15px;font-weight:600;text-decoration-line:none"
                       target="_blank">Contact Support</a>
                   </td>

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -146,6 +146,64 @@ class EventBooking(Document):
 		self.validate_coupon_availability()
 		self.generate_tickets()
 
+		try:
+			self.send_booking_confirmation_email()
+		except Exception as e:
+			frappe.log_error("Error sending booking confirmation email: " + str(e))
+
+	def send_booking_confirmation_email(self, now: bool = False):
+		# Never email system/placeholder users — they are not real recipients.
+		if self.user in ("Administrator", "Guest"):
+			return
+
+		send_email = frappe.get_cached_value("Buzz Event", self.event, "send_booking_confirmation_email")
+		if not send_email:
+			return
+
+		recipient = frappe.db.get_value("User", self.user, "email") or self.user
+		if not recipient:
+			return
+
+		event_title, booking_template, venue = frappe.get_cached_value(
+			"Buzz Event",
+			self.event,
+			["title", "booking_confirmation_email_template", "venue"],
+		)
+
+		# Fallback to global setting if event-level not set
+		if not booking_template:
+			booking_template = frappe.db.get_single_value(
+				"Buzz Settings", "default_booking_confirmation_email_template"
+			)
+
+		subject = _("Your booking for {0} is confirmed ✅").format(event_title)
+		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
+		args = {
+			"doc": self,
+			"event_doc": event_doc,
+			"event_title": event_title,
+			"venue": venue,
+		}
+
+		content = None
+		if booking_template:
+			from frappe.email.doctype.email_template.email_template import get_email_template
+
+			email_template = get_email_template(booking_template, args)
+			subject = email_template.get("subject")
+			content = email_template.get("message")
+
+		frappe.sendmail(
+			recipients=[recipient],
+			subject=subject,
+			content=content if booking_template else None,
+			template="booking_confirmation" if not booking_template else None,
+			args=args,
+			reference_doctype=self.doctype,
+			reference_name=self.name,
+			now=now,
+		)
+
 	def validate_coupon_availability(self):
 		"""Re-validate coupon with lock to prevent race condition."""
 		if not self.coupon_code:

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -196,7 +196,7 @@ class EventBooking(Document):
 		attendee_rows = [
 			{
 				"full_name": attendee.full_name
-				or " ".join(filter(None, [attendee.first_name, attendee.last_name])),
+				or " ".join(part for part in (attendee.first_name, attendee.last_name) if part),
 				"ticket_type_title": ticket_type_titles.get(attendee.ticket_type, attendee.ticket_type),
 				"number_of_add_ons": attendee.number_of_add_ons,
 				"amount": (attendee.amount or 0) + (attendee.add_on_total or 0),

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -178,11 +178,38 @@ class EventBooking(Document):
 
 		subject = _("Your booking for {0} is confirmed ✅").format(event_title)
 		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
+
+		# Pre-fetch ticket type titles in a single query so the email template
+		# loop stays a pure display operation (no per-attendee DB round-trips).
+		ticket_type_names = list({attendee.ticket_type for attendee in self.attendees})
+		ticket_type_titles = {}
+		if ticket_type_names:
+			ticket_type_titles = {
+				row.name: row.title
+				for row in frappe.get_all(
+					"Event Ticket Type",
+					filters={"name": ["in", ticket_type_names]},
+					fields=["name", "title"],
+				)
+			}
+
+		attendee_rows = [
+			{
+				"full_name": attendee.full_name
+				or " ".join(filter(None, [attendee.first_name, attendee.last_name])),
+				"ticket_type_title": ticket_type_titles.get(attendee.ticket_type, attendee.ticket_type),
+				"number_of_add_ons": attendee.number_of_add_ons,
+				"amount": (attendee.amount or 0) + (attendee.add_on_total or 0),
+			}
+			for attendee in self.attendees
+		]
+
 		args = {
 			"doc": self,
 			"event_doc": event_doc,
 			"event_title": event_title,
 			"venue": venue,
+			"attendee_rows": attendee_rows,
 		}
 
 		content = None

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -4,6 +4,7 @@ import json
 
 import frappe
 from frappe import _
+from frappe.email.doctype.email_template.email_template import get_email_template
 from frappe.model.document import Document
 
 from buzz.api import OFFLINE_PAYMENT_METHOD
@@ -148,36 +149,32 @@ class EventBooking(Document):
 
 		try:
 			self.send_booking_confirmation_email()
-		except Exception as e:
-			frappe.log_error("Error sending booking confirmation email: " + str(e))
+		except Exception:
+			frappe.log_error(
+				title="Booking confirmation email failed",
+				reference_doctype=self.doctype,
+				reference_name=self.name,
+			)
 
-	def send_booking_confirmation_email(self, now: bool = False):
+	def send_booking_confirmation_email(self):
 		# Never email system/placeholder users — they are not real recipients.
 		if self.user in ("Administrator", "Guest"):
 			return
 
-		send_email = frappe.get_cached_value("Buzz Event", self.event, "send_booking_confirmation_email")
-		if not send_email:
+		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
+		if not event_doc.send_booking_confirmation_email:
 			return
 
 		recipient = frappe.db.get_value("User", self.user, "email") or self.user
 		if not recipient:
 			return
 
-		event_title, booking_template, venue = frappe.get_cached_value(
-			"Buzz Event",
-			self.event,
-			["title", "booking_confirmation_email_template", "venue"],
+		# Fallback to global setting if event-level not set
+		booking_template = event_doc.booking_confirmation_email_template or frappe.db.get_single_value(
+			"Buzz Settings", "default_booking_confirmation_email_template"
 		)
 
-		# Fallback to global setting if event-level not set
-		if not booking_template:
-			booking_template = frappe.db.get_single_value(
-				"Buzz Settings", "default_booking_confirmation_email_template"
-			)
-
-		subject = _("Your booking for {0} is confirmed ✅").format(event_title)
-		event_doc = frappe.get_cached_doc("Buzz Event", self.event)
+		subject = _("Your booking for {0} is confirmed ✅").format(event_doc.title)
 
 		# Pre-fetch ticket type titles in a single query so the email template
 		# loop stays a pure display operation (no per-attendee DB round-trips).
@@ -207,28 +204,26 @@ class EventBooking(Document):
 		args = {
 			"doc": self,
 			"event_doc": event_doc,
-			"event_title": event_title,
-			"venue": venue,
+			"event_title": event_doc.title,
+			"venue": event_doc.venue,
 			"attendee_rows": attendee_rows,
+			"support_email": frappe.db.get_single_value("Buzz Settings", "support_email"),
 		}
 
 		content = None
 		if booking_template:
-			from frappe.email.doctype.email_template.email_template import get_email_template
-
 			email_template = get_email_template(booking_template, args)
-			subject = email_template.get("subject")
+			subject = email_template.get("subject") or subject
 			content = email_template.get("message")
 
 		frappe.sendmail(
 			recipients=[recipient],
 			subject=subject,
-			content=content if booking_template else None,
-			template="booking_confirmation" if not booking_template else None,
+			content=content,
+			template=None if booking_template else "booking_confirmation",
 			args=args,
 			reference_doctype=self.doctype,
 			reference_name=self.name,
-			now=now,
 		)
 
 	def validate_coupon_availability(self):

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1330,74 +1330,51 @@ class TestBookingConfirmationEmail(IntegrationTestCase):
 	def test_respects_event_toggle_off(self, mock_sendmail):
 		self.test_event.send_booking_confirmation_email = 0
 		self.test_event.save()
-		try:
-			booking = self._make_booking(self.BOOKER_EMAIL)
-			booking.submit()
-			mock_sendmail.assert_not_called()
-		finally:
-			self.test_event.send_booking_confirmation_email = 1
-			self.test_event.save()
+
+		booking = self._make_booking(self.BOOKER_EMAIL)
+		booking.submit()
+
+		mock_sendmail.assert_not_called()
 
 	@patch("frappe.sendmail")
 	def test_uses_event_template_when_set(self, mock_sendmail):
 		template = self._create_template("Booking Confirmation Event Template", "EVENT")
-		try:
-			self.test_event.booking_confirmation_email_template = template.name
-			self.test_event.save()
+		self.test_event.booking_confirmation_email_template = template.name
+		self.test_event.save()
 
-			booking = self._make_booking(self.BOOKER_EMAIL)
-			booking.submit()
+		booking = self._make_booking(self.BOOKER_EMAIL)
+		booking.submit()
 
-			mock_sendmail.assert_called_once()
-			self.assertIn("EVENT", mock_sendmail.call_args[1]["subject"])
-		finally:
-			self.test_event.booking_confirmation_email_template = None
-			self.test_event.save()
-			frappe.delete_doc("Email Template", template.name, force=True)
+		mock_sendmail.assert_called_once()
+		self.assertIn("EVENT", mock_sendmail.call_args[1]["subject"])
 
 	@patch("frappe.sendmail")
 	def test_falls_back_to_global_template(self, mock_sendmail):
 		template = self._create_template("Booking Confirmation Global Template", "GLOBAL")
 		settings = frappe.get_doc("Buzz Settings")
-		try:
-			self.test_event.booking_confirmation_email_template = None
-			self.test_event.save()
+		settings.default_booking_confirmation_email_template = template.name
+		settings.save()
 
-			settings.default_booking_confirmation_email_template = template.name
-			settings.save()
+		booking = self._make_booking(self.BOOKER_EMAIL)
+		booking.submit()
 
-			booking = self._make_booking(self.BOOKER_EMAIL)
-			booking.submit()
-
-			mock_sendmail.assert_called_once()
-			self.assertIn("GLOBAL", mock_sendmail.call_args[1]["subject"])
-		finally:
-			settings.default_booking_confirmation_email_template = None
-			settings.save()
-			frappe.delete_doc("Email Template", template.name, force=True)
+		mock_sendmail.assert_called_once()
+		self.assertIn("GLOBAL", mock_sendmail.call_args[1]["subject"])
 
 	@patch("frappe.sendmail")
 	def test_event_template_takes_precedence_over_global(self, mock_sendmail):
 		event_template = self._create_template("Booking Event Precedence Template", "EVENT")
 		global_template = self._create_template("Booking Global Precedence Template", "GLOBAL")
+		self.test_event.booking_confirmation_email_template = event_template.name
+		self.test_event.save()
+
 		settings = frappe.get_doc("Buzz Settings")
-		try:
-			self.test_event.booking_confirmation_email_template = event_template.name
-			self.test_event.save()
+		settings.default_booking_confirmation_email_template = global_template.name
+		settings.save()
 
-			settings.default_booking_confirmation_email_template = global_template.name
-			settings.save()
+		booking = self._make_booking(self.BOOKER_EMAIL)
+		booking.submit()
 
-			booking = self._make_booking(self.BOOKER_EMAIL)
-			booking.submit()
-
-			mock_sendmail.assert_called_once()
-			self.assertIn("EVENT", mock_sendmail.call_args[1]["subject"])
-			self.assertNotIn("GLOBAL", mock_sendmail.call_args[1]["subject"])
-		finally:
-			self.test_event.booking_confirmation_email_template = None
-			self.test_event.save()
-			settings.default_booking_confirmation_email_template = None
-			settings.save()
-			frappe.delete_doc("Email Template", event_template.name, force=True)
-			frappe.delete_doc("Email Template", global_template.name, force=True)
+		mock_sendmail.assert_called_once()
+		self.assertIn("EVENT", mock_sendmail.call_args[1]["subject"])
+		self.assertNotIn("GLOBAL", mock_sendmail.call_args[1]["subject"])

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1223,40 +1223,30 @@ class TestBookingConfirmationEmail(IntegrationTestCase):
 
 	BOOKER_EMAIL = "booker-56@example.com"
 
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		cls.test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
-		# Remember the original value so tearDownClass can restore the shared
-		# fixture — other test classes rely on the default send_ticket_email.
-		cls.original_send_ticket_email = cls.test_event.send_ticket_email
-		cls.test_event.apply_tax = False
-		cls.test_event.send_booking_confirmation_email = 1
-		cls.test_event.booking_confirmation_email_template = None
-		# Isolate the confirmation email: keep per-attendee ticket emails off so
-		# frappe.sendmail is only invoked by the booking confirmation logic.
-		cls.test_event.send_ticket_email = 0
-		cls.test_event.save()
+	def setUp(self):
+		# Configure the shared event and create fixtures per test (not in
+		# setUpClass) so every mutation lives inside the test's own transaction:
+		# nothing leaks into other test classes, and the booker User is
+		# guaranteed to exist when the booking's user link is validated.
+		self.test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		self.test_event.apply_tax = False
+		self.test_event.send_booking_confirmation_email = 1
+		self.test_event.booking_confirmation_email_template = None
+		# Keep per-attendee ticket emails off so frappe.sendmail is only invoked
+		# by the booking confirmation logic.
+		self.test_event.send_ticket_email = 0
+		self.test_event.save()
 
 		settings = frappe.get_doc("Buzz Settings")
 		settings.default_booking_confirmation_email_template = None
 		settings.save()
 
-	@classmethod
-	def tearDownClass(cls):
-		# Restore the shared test event so we don't leak send_ticket_email = 0
-		# into any test class that runs afterwards.
-		test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
-		test_event.send_ticket_email = cls.original_send_ticket_email
-		test_event.save()
-		super().tearDownClass()
-
 		# A real (non-system) booker whose User email is a valid recipient.
-		if not frappe.db.exists("User", cls.BOOKER_EMAIL):
+		if not frappe.db.exists("User", self.BOOKER_EMAIL):
 			frappe.get_doc(
 				{
 					"doctype": "User",
-					"email": cls.BOOKER_EMAIL,
+					"email": self.BOOKER_EMAIL,
 					"first_name": "Booker",
 					"enabled": 1,
 					"user_type": "Website User",
@@ -1264,7 +1254,6 @@ class TestBookingConfirmationEmail(IntegrationTestCase):
 				}
 			).insert(ignore_permissions=True)
 
-	def setUp(self):
 		self.ticket_type = frappe.get_doc(
 			{
 				"doctype": "Event Ticket Type",

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025, BWH Studios and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -1214,3 +1216,187 @@ class TestBookingConfirmation(IntegrationTestCase):
 		# Administrator owns/has perm — no token needed
 		result = get_booking_confirmation(booking.name)
 		self.assertEqual(result["booking"]["name"], booking.name)
+
+
+class TestBookingConfirmationEmail(IntegrationTestCase):
+	"""Confirmation email sent to the booker with a booking summary (issue #56)."""
+
+	BOOKER_EMAIL = "booker-56@example.com"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		cls.test_event.apply_tax = False
+		cls.test_event.send_booking_confirmation_email = 1
+		cls.test_event.booking_confirmation_email_template = None
+		# Isolate the confirmation email: keep per-attendee ticket emails off so
+		# frappe.sendmail is only invoked by the booking confirmation logic.
+		cls.test_event.send_ticket_email = 0
+		cls.test_event.save()
+
+		settings = frappe.get_doc("Buzz Settings")
+		settings.default_booking_confirmation_email_template = None
+		settings.save()
+
+		# A real (non-system) booker whose User email is a valid recipient.
+		if not frappe.db.exists("User", cls.BOOKER_EMAIL):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": cls.BOOKER_EMAIL,
+					"first_name": "Booker",
+					"enabled": 1,
+					"user_type": "Website User",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+
+	def setUp(self):
+		self.ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": self.test_event.name,
+				"title": "Confirmation Email Ticket",
+				"price": 100,
+			}
+		).insert()
+
+	def tearDown(self):
+		frappe.delete_doc("Event Ticket Type", self.ticket_type.name, force=True)
+
+	def _make_booking(self, user):
+		return frappe.get_doc(
+			{
+				"doctype": "Event Booking",
+				"event": self.test_event.name,
+				"user": user,
+				"attendees": [
+					{
+						"ticket_type": self.ticket_type.name,
+						"first_name": "John",
+						"email": "john-56@example.com",
+					}
+				],
+			}
+		).insert()
+
+	def _create_template(self, name, subject_prefix):
+		if frappe.db.exists("Email Template", name):
+			frappe.delete_doc("Email Template", name, force=True)
+		return frappe.get_doc(
+			{
+				"doctype": "Email Template",
+				"name": name,
+				"subject": f"{subject_prefix} - {{{{ event_title }}}}",
+				"response": f"<p>{subject_prefix} content</p>",
+			}
+		).insert()
+
+	@patch("frappe.sendmail")
+	def test_sends_confirmation_to_booker(self, mock_sendmail):
+		booking = self._make_booking(self.BOOKER_EMAIL)
+		booking.submit()
+
+		mock_sendmail.assert_called_once()
+		self.assertIn(self.BOOKER_EMAIL, mock_sendmail.call_args[1]["recipients"])
+		self.assertEqual(mock_sendmail.call_args[1]["reference_doctype"], "Event Booking")
+		self.assertEqual(mock_sendmail.call_args[1]["reference_name"], booking.name)
+
+	@patch("frappe.sendmail")
+	def test_uses_inline_template_when_none_configured(self, mock_sendmail):
+		booking = self._make_booking(self.BOOKER_EMAIL)
+		booking.submit()
+
+		mock_sendmail.assert_called_once()
+		self.assertEqual(mock_sendmail.call_args[1]["template"], "booking_confirmation")
+
+	@patch("frappe.sendmail")
+	def test_skips_administrator(self, mock_sendmail):
+		booking = self._make_booking("Administrator")
+		booking.submit()
+
+		mock_sendmail.assert_not_called()
+
+	@patch("frappe.sendmail")
+	def test_skips_guest(self, mock_sendmail):
+		booking = self._make_booking("Guest")
+		booking.submit()
+
+		mock_sendmail.assert_not_called()
+
+	@patch("frappe.sendmail")
+	def test_respects_event_toggle_off(self, mock_sendmail):
+		self.test_event.send_booking_confirmation_email = 0
+		self.test_event.save()
+		try:
+			booking = self._make_booking(self.BOOKER_EMAIL)
+			booking.submit()
+			mock_sendmail.assert_not_called()
+		finally:
+			self.test_event.send_booking_confirmation_email = 1
+			self.test_event.save()
+
+	@patch("frappe.sendmail")
+	def test_uses_event_template_when_set(self, mock_sendmail):
+		template = self._create_template("Booking Confirmation Event Template", "EVENT")
+		try:
+			self.test_event.booking_confirmation_email_template = template.name
+			self.test_event.save()
+
+			booking = self._make_booking(self.BOOKER_EMAIL)
+			booking.submit()
+
+			mock_sendmail.assert_called_once()
+			self.assertIn("EVENT", mock_sendmail.call_args[1]["subject"])
+		finally:
+			self.test_event.booking_confirmation_email_template = None
+			self.test_event.save()
+			frappe.delete_doc("Email Template", template.name, force=True)
+
+	@patch("frappe.sendmail")
+	def test_falls_back_to_global_template(self, mock_sendmail):
+		template = self._create_template("Booking Confirmation Global Template", "GLOBAL")
+		settings = frappe.get_doc("Buzz Settings")
+		try:
+			self.test_event.booking_confirmation_email_template = None
+			self.test_event.save()
+
+			settings.default_booking_confirmation_email_template = template.name
+			settings.save()
+
+			booking = self._make_booking(self.BOOKER_EMAIL)
+			booking.submit()
+
+			mock_sendmail.assert_called_once()
+			self.assertIn("GLOBAL", mock_sendmail.call_args[1]["subject"])
+		finally:
+			settings.default_booking_confirmation_email_template = None
+			settings.save()
+			frappe.delete_doc("Email Template", template.name, force=True)
+
+	@patch("frappe.sendmail")
+	def test_event_template_takes_precedence_over_global(self, mock_sendmail):
+		event_template = self._create_template("Booking Event Precedence Template", "EVENT")
+		global_template = self._create_template("Booking Global Precedence Template", "GLOBAL")
+		settings = frappe.get_doc("Buzz Settings")
+		try:
+			self.test_event.booking_confirmation_email_template = event_template.name
+			self.test_event.save()
+
+			settings.default_booking_confirmation_email_template = global_template.name
+			settings.save()
+
+			booking = self._make_booking(self.BOOKER_EMAIL)
+			booking.submit()
+
+			mock_sendmail.assert_called_once()
+			self.assertIn("EVENT", mock_sendmail.call_args[1]["subject"])
+			self.assertNotIn("GLOBAL", mock_sendmail.call_args[1]["subject"])
+		finally:
+			self.test_event.booking_confirmation_email_template = None
+			self.test_event.save()
+			settings.default_booking_confirmation_email_template = None
+			settings.save()
+			frappe.delete_doc("Email Template", event_template.name, force=True)
+			frappe.delete_doc("Email Template", global_template.name, force=True)

--- a/buzz/ticketing/doctype/event_booking/test_event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/test_event_booking.py
@@ -1227,6 +1227,9 @@ class TestBookingConfirmationEmail(IntegrationTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		cls.test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		# Remember the original value so tearDownClass can restore the shared
+		# fixture — other test classes rely on the default send_ticket_email.
+		cls.original_send_ticket_email = cls.test_event.send_ticket_email
 		cls.test_event.apply_tax = False
 		cls.test_event.send_booking_confirmation_email = 1
 		cls.test_event.booking_confirmation_email_template = None
@@ -1238,6 +1241,15 @@ class TestBookingConfirmationEmail(IntegrationTestCase):
 		settings = frappe.get_doc("Buzz Settings")
 		settings.default_booking_confirmation_email_template = None
 		settings.save()
+
+	@classmethod
+	def tearDownClass(cls):
+		# Restore the shared test event so we don't leak send_ticket_email = 0
+		# into any test class that runs afterwards.
+		test_event = frappe.get_doc("Buzz Event", {"route": "test-route"})
+		test_event.send_ticket_email = cls.original_send_ticket_email
+		test_event.save()
+		super().tearDownClass()
 
 		# A real (non-system) booker whose User email is a valid recipient.
 		if not frappe.db.exists("User", cls.BOOKER_EMAIL):


### PR DESCRIPTION
## Summary

Closes #56.

Today the system only emails the **per-attendee tickets** (with QR codes). The person who actually made the booking never gets a confirmation summarizing what they booked. This PR adds a **booking confirmation email** sent to the booker when a booking is submitted, alongside the existing ticket emails.

## What changed

- **`EventBooking.send_booking_confirmation_email()`** — new method called from `on_submit()` after `generate_tickets()`, wrapped in a defensive `try/except` + `frappe.log_error` (same pattern as `EventTicket.send_ticket_email`).
  - Recipient is `booking.user`'s email.
  - **System/placeholder users are skipped** — if `booking.user` is `Administrator` or `Guest`, no email is sent.
  - Respects an event-level on/off toggle.
  - Template resolution mirrors the ticket email: **event-level template → Buzz Settings default → built-in `booking_confirmation` template**.
- **Schema** (mirrors the ticket-email config for consistency):
  - Buzz Event: `send_booking_confirmation_email` (Check, default on) + `booking_confirmation_email_template` (Link → Email Template).
  - Buzz Settings: `default_booking_confirmation_email_template` (Link → Email Template) as global fallback.
- **New template** `buzz/templates/emails/booking_confirmation.html` — booking summary styled like `ticket.html`: event header, booking ID, attendee/ticket-type list, subtotal, discount (with coupon), tax (with label), total, and payment status.

## Tests

Added `TestBookingConfirmationEmail` (patches `frappe.sendmail`, same style as the existing ticket-email tests):

- sends to the booker's email with the booking as `reference_doctype`/`reference_name`
- uses the built-in `booking_confirmation` template when nothing is configured
- **skips `Administrator`** and **skips `Guest`**
- respects the event toggle being off
- event template → global fallback → event-template-takes-precedence resolution chain

## Notes for reviewer

- Requires **`bench migrate`** to add the new DocType fields.
- The new event toggle defaults **on**, so existing events start sending confirmations after migrate (opt-out), consistent with `send_ticket_email`.
- This environment has no Frappe/bench install, so the test suite was **not run locally** — CI should exercise `buzz.ticketing.doctype.event_booking.test_event_booking`. `ruff check`/`format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WyvrbrsHCueN5njnomknX

---
_Generated by [Claude Code](https://claude.ai/code/session_013WyvrbrsHCueN5njnomknX)_