### PR TITLE
fix(dashboard): truncate long ListView columns instead of horizontal scroll

### DIFF
--- a/dashboard/src/pages/BookingsList.vue
+++ b/dashboard/src/pages/BookingsList.vue
@@ -17,7 +17,7 @@
 				},
 			}"
 		>
-			<template #cell="{ item, row, column }">
+			<template #cell="{ item, row, column, align }">
 				<Badge
 					v-if="column.key === 'status'"
 					:theme="
@@ -32,7 +32,7 @@
 				>
 					{{ item }}
 				</Badge>
-				<span v-else>{{ item }}</span>
+				<ListRowItem v-else :column="column" :row="row" :item="item" :align="align" />
 			</template>
 		</ListView>
 	</div>
@@ -41,17 +41,17 @@
 <script setup>
 import { formatCurrency } from "@/utils/currency";
 import { pluralize } from "@/utils/pluralize";
-import { Badge, ListView, useList } from "frappe-ui";
+import { Badge, ListRowItem, ListView, useList } from "frappe-ui";
 import { dayjsLocal } from "frappe-ui";
 import { session } from "../data/session";
 
 const columns = [
-	{ label: __("Event"), key: "event_title" },
-	{ label: "", key: "ticket_count" },
-	{ label: __("Start Date"), key: "start_date" },
-	{ label: __("Venue"), key: "venue" },
-	{ label: __("Amount Paid"), key: "formatted_amount" },
-	{ label: __("Status"), key: "status" },
+	{ label: __("Event"), key: "event_title", width: "220px" },
+	{ label: "", key: "ticket_count", width: "90px" },
+	{ label: __("Start Date"), key: "start_date", width: "110px" },
+	{ label: __("Venue"), key: "venue", width: "140px" },
+	{ label: __("Amount Paid"), key: "formatted_amount", width: "110px" },
+	{ label: __("Status"), key: "status", width: "120px" },
 ];
 
 const bookings = useList({

--- a/dashboard/src/pages/ProposalsList.vue
+++ b/dashboard/src/pages/ProposalsList.vue
@@ -17,7 +17,7 @@
 				},
 			}"
 		>
-			<template #cell="{ item, row, column }">
+			<template #cell="{ item, row, column, align }">
 				<Badge
 					v-if="column.key === 'status'"
 					:theme="getStatusTheme(row.status)"
@@ -26,7 +26,7 @@
 				>
 					{{ item }}
 				</Badge>
-				<span v-else>{{ item }}</span>
+				<ListRowItem v-else :column="column" :row="row" :item="item" :align="align" />
 			</template>
 		</ListView>
 
@@ -48,15 +48,15 @@
 <script setup>
 import { session } from "@/data/session";
 import { useProposalStatuses } from "@/composables/useProposalStatuses";
-import { Badge, ListView, Spinner, dayjsLocal, useList } from "frappe-ui";
+import { Badge, ListRowItem, ListView, Spinner, dayjsLocal, useList } from "frappe-ui";
 
 const { getStatusTheme } = useProposalStatuses();
 
 const columns = [
-	{ label: __("Title"), key: "title" },
-	{ label: __("Event"), key: "event_title" },
-	{ label: __("Status"), key: "status" },
-	{ label: __("Submitted"), key: "formatted_creation" },
+	{ label: __("Title"), key: "title", width: "240px" },
+	{ label: __("Event"), key: "event_title", width: "180px" },
+	{ label: __("Status"), key: "status", width: "130px" },
+	{ label: __("Submitted"), key: "formatted_creation", width: "120px" },
 ];
 
 const proposals = useList({


### PR DESCRIPTION
## Summary
- My Bookings and Talk Proposals lists overflowed horizontally on long text — user had to scroll to see leftmost columns.
- Restore truncate + tooltip-on-hover for non-status cells (`ListRowItem`), previously lost by the custom `#cell` slot fallback.
- Give each column a fixed px width — `ListView`'s wrapper sizes to content (`w-max`), so flexible `fr`/`minmax` tracks don't shrink; only fixed widths let truncation actually clip.

Verified live in browser with a long event title — text now ellipsizes, all columns stay visible, no horizontal scroll.

Fixes #226

## Test plan
- [x] Booked events list: long title truncates with ellipsis, all 6 columns visible
- [x] Talk Proposals list: layout unaffected, status badges still render
- [x] pre-commit (prettier) passes