### PR TITLE
ci: add label-driven backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,40 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    # Only run on merged PRs that carry a backport label. The `labeled` event
+    # lets you trigger a backport after the PR is already merged by adding the
+    # label late.
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        github.event.action == 'closed' ||
+        startsWith(github.event.label.name, 'backport ')
+      )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create backport PRs
+        uses: korthout/backport-action@v3
+        with:
+          # Act only on labels shaped like "backport <target-branch>",
+          # e.g. "backport main".
+          label_pattern: '^backport ([^ ]+)$'
+          pull_title: '[Backport ${target_branch}] ${pull_title}'
+          pull_description: |
+            Automated backport of #${pull_number} to `${target_branch}`.
+          # Carry the original PR's labels onto the backport PR.
+          copy_labels_pattern: '.*'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create backport PRs
-        uses: korthout/backport-action@v3
+        uses: korthout/backport-action@d07416681cab29bf2661702f925f020aaa962997 # v3.4.1
         with:
           # Act only on labels shaped like "backport <target-branch>",
           # e.g. "backport main".
@@ -36,5 +36,7 @@ jobs:
           pull_title: '[Backport ${target_branch}] ${pull_title}'
           pull_description: |
             Automated backport of #${pull_number} to `${target_branch}`.
-          # Carry the original PR's labels onto the backport PR.
-          copy_labels_pattern: '.*'
+          # Carry the original PR's labels onto the backport PR, except the
+          # "backport <branch>" label itself — copying it would re-trigger this
+          # workflow when the generated PR is merged.
+          copy_labels_pattern: '^(?!backport ).*'


### PR DESCRIPTION
## What

Adds `.github/workflows/backport.yml`, a label-driven GitHub Action ([`korthout/backport-action`](https://github.com/korthout/backport-action)) that automates cherry-picking a merged PR onto a maintenance branch.

## Why

We just cut `1.0.0`. With `develop` as the forward line and `main` as the stable **v1** line, any v1 fix now has to land in two places. Doing that by hand is easy to forget, so fixes silently miss the release line. This makes the backport one label away.

## How it works

1. Add a `backport main` label to a PR against `develop`.
2. On merge, the action cherry-picks the (squashed) commit onto `main` and opens a `[Backport main] …` PR linking back to the original. Normal CI runs on it.
3. **On conflict** it does not open a PR — it comments the manual `git` steps on the original PR so nothing is silently dropped.

The `label_pattern: '^backport ([^ ]+)$'` scales to future lines (`backport <branch>`) without editing the workflow.

## Follow-ups (not in this PR)

- Create the labels: `backport main` (and optionally `backport-failed`, `no-backport`).
- Standardize `develop` on **squash-merge** so each backport is one clean cherry-pick.
- Optional: add `develop` to the `push` trigger in `ci.yml` so the dev line is tested on merge too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PntNpMSKA2tkugCR3rupb

---
_Generated by [Claude Code](https://claude.ai/code/session_013PntNpMSKA2tkugCR3rupb)_