### PR TITLE
feat(proposals): speakers can see and edit their talk proposals

### DIFF
--- a/buzz/api/proposals.py
+++ b/buzz/api/proposals.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+import frappe
+from pydantic import BaseModel
+
+
+class ProposalListItem(BaseModel):
+	name: str
+	title: str
+	event: str
+	event_title: str | None = None
+	status: str
+	creation: datetime
+
+
+@frappe.whitelist()
+def get_my_proposals() -> list[dict]:
+	"""Proposals where the session user is the submitter or a listed speaker.
+
+	Speaker matching runs on the speakers child table because guest form
+	submissions leave submitted_by as "Guest".
+	"""
+	user = frappe.session.user
+
+	speaker_proposal_names = frappe.get_all(
+		"Proposal Speaker",
+		filters={"parenttype": "Talk Proposal", "email": user},
+		pluck="parent",
+	)
+
+	rows = frappe.get_all(
+		"Talk Proposal",
+		or_filters={
+			"submitted_by": user,
+			"name": ["in", speaker_proposal_names],
+		},
+		fields=["name", "title", "event", "event.title as event_title", "status", "creation"],
+		order_by="creation desc",
+	)
+
+	return [ProposalListItem(**row).model_dump() for row in rows]

--- a/buzz/api/test_proposals.py
+++ b/buzz/api/test_proposals.py
@@ -1,0 +1,59 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils.data import cstr
+
+from buzz.api.proposals import get_my_proposals
+from buzz.api.test_forms import ensure_prompt_named_record
+from buzz.proposals.doctype.talk_proposal.test_talk_proposal import (
+	make_guest_proposal,
+	make_test_event,
+	make_test_user,
+)
+
+
+class TestGetMyProposals(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "My Proposals Category")
+		cls.host = ensure_prompt_named_record("Event Host", "My Proposals Host")
+		cls.event = make_test_event(cls.category, cls.host)
+		cls.speaker_user = make_test_user("speaker-api@example.com")
+		cls.other_user = make_test_user("other-api@example.com")
+		cls.guest_proposal = make_guest_proposal(cls.event, cls.speaker_user)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_returns_guest_submitted_proposal_for_speaker(self):
+		frappe.set_user(self.speaker_user)
+		names = [row["name"] for row in get_my_proposals()]
+		self.assertIn(self.guest_proposal, names)
+
+	def test_returns_proposal_submitted_by_user_without_speaker_row(self):
+		proposal = frappe.get_doc(
+			{
+				"doctype": "Talk Proposal",
+				"title": f"Submitter API Talk {frappe.generate_hash(length=6)}",
+				"event": self.event,
+				"submitted_by": self.speaker_user,
+				"speakers": [{"first_name": "Someone", "email": "someone-else@example.com"}],
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user(self.speaker_user)
+		names = [row["name"] for row in get_my_proposals()]
+		self.assertIn(proposal.name, names)
+
+	def test_excludes_unrelated_proposals(self):
+		frappe.set_user(self.other_user)
+		names = [row["name"] for row in get_my_proposals()]
+		self.assertNotIn(self.guest_proposal, names)
+
+	def test_rows_have_expected_shape(self):
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in get_my_proposals() if r["name"] == self.guest_proposal)
+		self.assertEqual(row["event"], cstr(self.event))
+		self.assertEqual(row["status"], "Review Pending")
+		for key in ("name", "title", "event_title", "creation"):
+			self.assertIn(key, row)

--- a/buzz/hooks.py
+++ b/buzz/hooks.py
@@ -189,6 +189,14 @@ after_migrate = "buzz.install.on_migrate"
 # 	"Event": "frappe.desk.doctype.event.event.has_permission",
 # }
 
+permission_query_conditions = {
+	"Talk Proposal": "buzz.proposals.doctype.talk_proposal.talk_proposal.get_permission_query_conditions",
+}
+
+has_permission = {
+	"Talk Proposal": "buzz.proposals.doctype.talk_proposal.talk_proposal.has_talk_proposal_permission",
+}
+
 # Document Events
 # ---------------
 # Hook on document methods and events

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.json
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.json
@@ -99,7 +99,7 @@
    "link_fieldname": "proposal"
   }
  ],
- "modified": "2026-06-21 09:15:43.483668",
+ "modified": "2026-07-22 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Proposals",
  "name": "Talk Proposal",
@@ -134,7 +134,6 @@
    "create": 1,
    "email": 1,
    "export": 1,
-   "if_owner": 1,
    "print": 1,
    "read": 1,
    "report": 1,

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.py
@@ -39,7 +39,9 @@ def has_talk_proposal_permission(doc, ptype: str | None = None, user: str | None
 		return True
 	if user in (doc.submitted_by, doc.owner):
 		return True
-	return any(speaker.email == user for speaker in doc.speakers)
+	# User emails are stored lowercase, but guest-entered speaker emails keep
+	# their original casing.
+	return any(speaker.email and speaker.email.lower() == user.lower() for speaker in doc.speakers)
 
 
 class TalkProposal(Document):

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.py
@@ -5,6 +5,42 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
+PROPOSAL_MANAGER_ROLES = frozenset({"System Manager", "Event Manager"})
+
+
+def is_proposal_manager(user: str) -> bool:
+	return user == "Administrator" or bool(PROPOSAL_MANAGER_ROLES & set(frappe.get_roles(user)))
+
+
+def get_permission_query_conditions(user: str | None = None) -> str:
+	user = user or frappe.session.user
+	if is_proposal_manager(user):
+		return ""
+
+	escaped_user = frappe.db.escape(user)
+	# Guest form submissions leave owner/submitted_by as "Guest", so speakers
+	# are matched by their email in the speakers child table.
+	return (
+		f"(`tabTalk Proposal`.`submitted_by` = {escaped_user}"
+		f" or `tabTalk Proposal`.`owner` = {escaped_user}"
+		f" or `tabTalk Proposal`.`name` in ("
+		f"select `parent` from `tabProposal Speaker`"
+		f" where `parenttype` = 'Talk Proposal' and `email` = {escaped_user}))"
+	)
+
+
+def has_talk_proposal_permission(doc, ptype: str | None = None, user: str | None = None) -> bool:
+	# Controller hooks can only deny access: True means "no objection" and
+	# role permissions still apply, False blocks the document outright.
+	user = user or frappe.session.user
+	if ptype == "create" or doc.is_new():
+		return True
+	if is_proposal_manager(user):
+		return True
+	if user in (doc.submitted_by, doc.owner):
+		return True
+	return any(speaker.email == user for speaker in doc.speakers)
+
 
 class TalkProposal(Document):
 	# begin: auto-generated types

--- a/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
@@ -117,6 +117,16 @@ class TestTalkProposalSpeakerAccess(IntegrationTestCase):
 		self.assertIn(proposal.name, frappe.get_list("Talk Proposal", pluck="name"))
 		self.assertTrue(proposal.has_permission("read"))
 
+	def test_speaker_email_match_is_case_insensitive(self):
+		proposal = make_guest_proposal(self.event, "Mixed-Case@Example.COM")
+		user = make_test_user("mixed-case@example.com")
+
+		frappe.set_user(user)
+		doc = frappe.get_doc("Talk Proposal", proposal)
+		self.assertTrue(doc.has_permission("read"))
+		self.assertTrue(doc.has_permission("write"))
+		self.assertIn(proposal, frappe.get_list("Talk Proposal", pluck="name"))
+
 	def test_event_manager_sees_all_proposals(self):
 		frappe.set_user(self.manager_user)
 		self.assertIn(self.guest_proposal, frappe.get_list("Talk Proposal", pluck="name"))

--- a/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2025, BWH Studios and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
+
+from buzz.api.test_forms import ensure_prompt_named_record
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
@@ -11,10 +13,110 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-class IntegrationTestTalkProposal(IntegrationTestCase):
-	"""
-	Integration tests for TalkProposal.
-	Use this class for testing interactions between multiple components.
-	"""
+def make_test_user(email: str, roles: list[str] | None = None) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True)
+	user = frappe.get_doc("User", email)
+	user.add_roles("Buzz User", *(roles or []))
+	return user.name
 
-	pass
+
+def make_test_event(category: str, host: str) -> str:
+	event = frappe.new_doc("Buzz Event")
+	event.update(
+		{
+			"title": f"Proposal Perm Event {frappe.generate_hash(length=6)}",
+			"start_date": "2030-01-01",
+			"end_date": "2030-01-01",
+			"start_time": "10:00:00",
+			"end_time": "18:00:00",
+			"medium": "Online",
+			"category": category,
+			"host": host,
+			"is_published": 1,
+		}
+	)
+	event.insert(ignore_permissions=True)
+	return event.name
+
+
+def make_guest_proposal(event: str, speaker_email: str, title: str | None = None) -> str:
+	"""Simulate a guest form submission: owner and submitted_by both end up 'Guest'."""
+	original_user = frappe.session.user
+	frappe.set_user("Guest")
+	try:
+		proposal = frappe.get_doc(
+			{
+				"doctype": "Talk Proposal",
+				"title": title or f"Guest Talk {frappe.generate_hash(length=6)}",
+				"event": event,
+				"speakers": [{"first_name": "Speaker", "email": speaker_email}],
+			}
+		).insert(ignore_permissions=True)
+	finally:
+		frappe.set_user(original_user)
+	return proposal.name
+
+
+class TestTalkProposalSpeakerAccess(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Proposal Perm Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Proposal Perm Host")
+		cls.event = make_test_event(cls.category, cls.host)
+		cls.speaker_user = make_test_user("speaker-perm@example.com")
+		cls.other_user = make_test_user("other-perm@example.com")
+		cls.manager_user = make_test_user("manager-perm@example.com", roles=["Event Manager"])
+		cls.guest_proposal = make_guest_proposal(cls.event, cls.speaker_user)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_speaker_can_read_guest_submitted_proposal(self):
+		frappe.set_user(self.speaker_user)
+		proposal = frappe.get_doc("Talk Proposal", self.guest_proposal)
+		self.assertTrue(proposal.has_permission("read"))
+
+	def test_speaker_can_write_guest_submitted_proposal(self):
+		frappe.set_user(self.speaker_user)
+		proposal = frappe.get_doc("Talk Proposal", self.guest_proposal)
+		self.assertTrue(proposal.has_permission("write"))
+
+	def test_speaker_sees_guest_submitted_proposal_in_list(self):
+		frappe.set_user(self.speaker_user)
+		names = frappe.get_list("Talk Proposal", pluck="name")
+		self.assertIn(self.guest_proposal, names)
+
+	def test_non_speaker_cannot_read_or_list_proposal(self):
+		frappe.set_user(self.other_user)
+		proposal = frappe.get_doc("Talk Proposal", self.guest_proposal)
+		self.assertFalse(proposal.has_permission("read"))
+		self.assertFalse(proposal.has_permission("write"))
+		self.assertNotIn(self.guest_proposal, frappe.get_list("Talk Proposal", pluck="name"))
+
+	def test_submitter_sees_proposal_even_without_speaker_row(self):
+		proposal = frappe.get_doc(
+			{
+				"doctype": "Talk Proposal",
+				"title": f"Submitter Talk {frappe.generate_hash(length=6)}",
+				"event": self.event,
+				"submitted_by": self.speaker_user,
+				"speakers": [{"first_name": "Someone", "email": "someone-else@example.com"}],
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user(self.speaker_user)
+		self.assertIn(proposal.name, frappe.get_list("Talk Proposal", pluck="name"))
+		self.assertTrue(proposal.has_permission("read"))
+
+	def test_event_manager_sees_all_proposals(self):
+		frappe.set_user(self.manager_user)
+		self.assertIn(self.guest_proposal, frappe.get_list("Talk Proposal", pluck="name"))

--- a/dashboard/src/pages/Account.vue
+++ b/dashboard/src/pages/Account.vue
@@ -27,8 +27,7 @@
 
 <script setup lang="ts">
 import ProfileView from "@/components/ProfileView.vue";
-import { session } from "@/data/session";
-import { Tabs, createResource, useList } from "frappe-ui";
+import { Tabs, createResource } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import LucideCalendarDays from "~icons/lucide/calendar-days";
@@ -38,13 +37,6 @@ import LucideTicket from "~icons/lucide/ticket";
 
 const route = useRoute();
 const router = useRouter();
-
-const proposals = useList({
-	doctype: "Talk Proposal",
-	fields: ["name"],
-	filters: { submitted_by: session.user },
-	cacheKey: ["account-proposals-check", session.user],
-});
 
 const sponsorships = createResource({
 	url: "buzz.api.get_user_sponsorship_inquiries",
@@ -63,13 +55,11 @@ const tabs = computed(() => {
 		{ label: __("My Tickets"), route: "/account/tickets", icon: LucideTicket },
 	];
 
-	if (proposals.data?.length) {
-		accountTabs.push({
-			label: __("Talk Proposals"),
-			route: "/account/proposals",
-			icon: LucideMegaphone,
-		});
-	}
+	accountTabs.push({
+		label: __("Talk Proposals"),
+		route: "/account/proposals",
+		icon: LucideMegaphone,
+	});
 
 	if (sponsorships.data?.length) {
 		accountTabs.push({
@@ -108,15 +98,10 @@ const getTabIndexFromRoute = () => {
 const tabIndex = ref(getTabIndexFromRoute());
 
 watch(
-	[
-		() => route.path,
-		() => tabs.value.length,
-		() => proposals.loading,
-		() => sponsorships.loading,
-	],
+	[() => route.path, () => tabs.value.length, () => sponsorships.loading],
 	() => {
 		const onKnownTab = tabs.value.some((tab) => route.path.startsWith(tab.route));
-		const settled = !proposals.loading && !sponsorships.loading;
+		const settled = !sponsorships.loading;
 		if (!onKnownTab && settled && route.path.startsWith("/account/")) {
 			router.replace(tabs.value[0].route);
 			return;

--- a/dashboard/src/pages/Account.vue
+++ b/dashboard/src/pages/Account.vue
@@ -53,13 +53,12 @@ const tabs = computed(() => {
 			icon: LucideCalendarDays,
 		},
 		{ label: __("My Tickets"), route: "/account/tickets", icon: LucideTicket },
+		{
+			label: __("Talk Proposals"),
+			route: "/account/proposals",
+			icon: LucideMegaphone,
+		},
 	];
-
-	accountTabs.push({
-		label: __("Talk Proposals"),
-		route: "/account/proposals",
-		icon: LucideMegaphone,
-	});
 
 	if (sponsorships.data?.length) {
 		accountTabs.push({

--- a/dashboard/src/pages/ProposalsList.vue
+++ b/dashboard/src/pages/ProposalsList.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script setup lang="ts">
+import { session } from "@/data/session";
 import { useProposalStatuses } from "@/composables/useProposalStatuses";
 import type { ProposalListItem } from "@/types";
 import { Badge, ListRowItem, ListView, Spinner, createResource, dayjsLocal } from "frappe-ui";
@@ -71,7 +72,7 @@ interface ProposalRow extends ProposalListItem {
 const proposals = createResource({
 	url: "buzz.api.proposals.get_my_proposals",
 	auto: true,
-	cache: "proposals-list",
+	cache: ["proposals-list", session.user],
 	transform: (data: ProposalListItem[]): ProposalRow[] =>
 		data.map((proposal) => ({
 			...proposal,

--- a/dashboard/src/pages/ProposalsList.vue
+++ b/dashboard/src/pages/ProposalsList.vue
@@ -49,9 +49,9 @@
 </template>
 
 <script setup lang="ts">
-import { session } from "@/data/session";
 import { useProposalStatuses } from "@/composables/useProposalStatuses";
-import { Badge, ListRowItem, ListView, Spinner, dayjsLocal, useList } from "frappe-ui";
+import type { ProposalListItem } from "@/types";
+import { Badge, ListRowItem, ListView, Spinner, createResource, dayjsLocal } from "frappe-ui";
 
 const { getStatusTheme } = useProposalStatuses();
 
@@ -62,19 +62,20 @@ const columns = [
 	{ label: __("Submitted"), key: "formatted_creation", width: "120px" },
 ];
 
-const proposals = useList({
-	doctype: "Talk Proposal",
-	fields: ["name", "title", "event.title as event_title", "status", "creation"],
-	filters: {
-		submitted_by: session.user,
-	},
-	orderBy: "creation desc",
-	cacheKey: ["proposals-list", session.user],
-	transform(data: any[]) {
-		return data.map((proposal: Record<string, any>) => ({
+interface ProposalRow extends ProposalListItem {
+	formatted_creation: string;
+}
+
+// Server-side scoping (submitter or listed speaker) instead of a client
+// filter, so guest-submitted proposals show up for their speakers too.
+const proposals = createResource({
+	url: "buzz.api.proposals.get_my_proposals",
+	auto: true,
+	cache: "proposals-list",
+	transform: (data: ProposalListItem[]): ProposalRow[] =>
+		data.map((proposal) => ({
 			...proposal,
 			formatted_creation: dayjsLocal(proposal.creation).format("MMM DD, YYYY"),
-		}));
-	},
+		})),
 });
 </script>

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -12,6 +12,17 @@ import type { FrappeField } from "@/composables/useCustomFields"
 import type { EventTicket } from "@/types/Ticketing/EventTicket"
 import type { TicketAddOnValue } from "@/types/Ticketing/TicketAddOnValue"
 
+// Rows from buzz.api.proposals.get_my_proposals: proposals where the session
+// user is the submitter or a listed speaker, with the event title joined on.
+export interface ProposalListItem {
+	name: string
+	title: string
+	event: string
+	event_title: string | null
+	status: string
+	creation: string
+}
+
 // Errors rejected by frappe-ui resources carry server messages beyond Error.
 export interface FrappeError extends Error {
 	messages?: string[]


### PR DESCRIPTION
## Problem

Guest form submissions store `submitted_by` (and `owner`) as `Guest`. The dashboard listed proposals by `submitted_by = session.user`, and the `if_owner` DocPerm restricted reads to `owner = user` — so speakers who submitted as guest and created an account later could never see or edit their proposals, even though their email is right there in the `speakers` child table.

## Fix

Visibility now derives from the `speakers` child table (any listed speaker email), plus submitter/owner:

- **Row-level access via hooks** — `permission_query_conditions` scopes list queries, `has_permission` guards single-document read/write. System Manager / Event Manager stay unrestricted. Replaces the `if_owner` restriction on Buzz User (which hooks cannot override and which blocked guest-owned docs).
- **`buzz.api.proposals.get_my_proposals`** — typed (pydantic) endpoint returning proposals where the session user is submitter or listed speaker, so the dashboard tab stays personal even for managers who can read everything.
- **`ProposalsList.vue`** — swaps `useList` + `submitted_by` filter for the new API.

## Tests

TDD — 10 new integration tests (`test_talk_proposal.py`, `test_proposals.py`) covering speaker read/write/list on guest-submitted proposals, submitter-without-speaker-row, non-speaker denial, and manager access. `buzz.api.test_forms` still green.

Note: speaker emails are self-reported on guest forms, so anyone listed as speaker gains view/edit on that proposal — same trust level as the form itself, flagged as a conscious call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)