### PR TITLE
ci: fix merge-queue trigger gaps and run CI on develop + main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,13 @@ name: CI
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   merge_group:
 
 concurrency:
-  group: main-buzz-${{ github.event.number || github.sha }}
+  group: ci-buzz-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,10 +3,14 @@ name: Linters
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   merge_group:
   workflow_dispatch:
+  schedule:
+    # Weekly dependency-advisory sweep (Mondays 00:00 UTC), independent of any PR.
+    - cron: '0 0 * * 1'
 
 permissions:
   contents: read
@@ -19,7 +23,9 @@ jobs:
   linter:
     name: 'Frappe Linter'
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Runs on PRs, pushes to develop/main, and in the merge queue so lint is
+    # actually enforced before code lands (not just on the PR head).
+    if: github.event_name != 'schedule'
 
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +46,10 @@ jobs:
   deps-vulnerable-check:
     name: 'Vulnerable Dependency Check'
     runs-on: ubuntu-latest
+    # pip-audit reads an external advisory DB, so its result depends on when it
+    # runs, not on the diff. Keep it off merge_group/push so a freshly published
+    # CVE can't block a queued merge; run it on PRs and on a weekly schedule.
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
 
     steps:
       - uses: actions/setup-python@v5

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,6 @@ on:
   merge_group:
   workflow_dispatch:
   schedule:
-    # Weekly dependency-advisory sweep (Mondays 00:00 UTC), independent of any PR.
     - cron: '0 0 * * 1'
 
 permissions:
@@ -23,8 +22,6 @@ jobs:
   linter:
     name: 'Frappe Linter'
     runs-on: ubuntu-latest
-    # Runs on PRs, pushes to develop/main, and in the merge queue so lint is
-    # actually enforced before code lands (not just on the PR head).
     if: github.event_name != 'schedule'
 
     steps:
@@ -46,9 +43,7 @@ jobs:
   deps-vulnerable-check:
     name: 'Vulnerable Dependency Check'
     runs-on: ubuntu-latest
-    # pip-audit reads an external advisory DB, so its result depends on when it
-    # runs, not on the diff. Keep it off merge_group/push so a freshly published
-    # CVE can't block a queued merge; run it on PRs and on a weekly schedule.
+    # Off merge_group/push so a newly published CVE can't block a queued merge.
     if: github.event_name == 'pull_request' || github.event_name == 'schedule'
 
     steps:

--- a/.github/workflows/pr-tittle-check.yml
+++ b/.github/workflows/pr-tittle-check.yml
@@ -7,9 +7,7 @@ on:
       - reopened
       - synchronize
       - edited
-  # Required status checks must report on the merge_group commit or the queue
-  # waits forever. The title can't change in the queue, so we report success
-  # without re-validating (see the step-level guard below).
+  # Report on the queue commit (title is fixed there, so the step below no-ops).
   merge_group:
 
 permissions:

--- a/.github/workflows/pr-tittle-check.yml
+++ b/.github/workflows/pr-tittle-check.yml
@@ -7,6 +7,10 @@ on:
       - reopened
       - synchronize
       - edited
+  # Required status checks must report on the merge_group commit or the queue
+  # waits forever. The title can't change in the queue, so we report success
+  # without re-validating (see the step-level guard below).
+  merge_group:
 
 permissions:
   pull-requests: write
@@ -17,6 +21,7 @@ jobs:
     steps:
       - name: Validate PR title
         id: validate
+        if: github.event_name != 'merge_group'
         uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -3,6 +3,7 @@ name: Dashboard TypeScript
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   merge_group:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -3,6 +3,7 @@ name: UI Tests
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   merge_group:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,7 @@ name: Dashboard Unit Tests
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   merge_group:


### PR DESCRIPTION
## Summary

Audit of the CI workflow triggers, plus adjustments for the default branch move to `develop` (while keeping CI running on `main` too).

Two workflows had required status checks that don't behave correctly with the merge queue — the flagship being the PR-title check, which never reports on the `merge_group` commit and leaves the queue stuck *"Expected — Waiting for status to be reported."*

## Changes

**Branch coverage (default branch is now `develop`)**
- `ci.yml`, `typecheck.yml`, `unit-tests.yml`, `ui-tests.yml`: add `develop` to `push.branches` (kept `main`). `pull_request` stays unfiltered so PRs to either branch still run.

**Merge-queue correctness**
- `pr-tittle-check.yml`: add a `merge_group` trigger and guard the validation step with `if: github.event_name != 'merge_group'`. The check now reports success on the queue commit instead of hanging forever (the title can't change inside the queue, so there's nothing to re-validate).
- `linter.yml` → **Frappe Linter**: drop `if: github.event_name == 'pull_request'` so lint is actually enforced in the merge queue. Previously it was skipped there, and a skipped required check counts as green — i.e. lint was silently bypassed on the way in.

**Dependency scan timing**
- `linter.yml` → **Vulnerable Dependency Check**: restrict to `pull_request` plus a new weekly `schedule` (Mondays 00:00 UTC), and keep it off `merge_group`/`push`. `pip-audit` reads an external advisory DB, so its result depends on *when* it runs — running it in the queue meant a freshly published CVE could block an otherwise-good merge on something the author can't fix.

**Cosmetic**
- `ci.yml`: rename concurrency prefix `main-buzz-*` → `ci-buzz-*` now that `main` isn't the default branch. No functional effect (concurrency group names don't affect required-check names).

## Notes / follow-up
- No job names changed, so branch-protection required-check names stay valid.
- Worth confirming whether the merge queue is enabled on `develop` only or on `main` too, so the required-check list in branch protection is set for the right branch(es). This PR's `on:` blocks work for either since `merge_group` needs no branch filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013EYfuce7SdhQDyZNCRMaNa)_