### PR TITLE
ci: keep backport PR titles conventional

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,9 +33,13 @@ jobs:
           # Act only on labels shaped like "backport <target-branch>",
           # e.g. "backport main".
           label_pattern: '^backport ([^ ]+)$'
-          pull_title: '[Backport ${target_branch}] ${pull_title}'
+          # Reuse the source title verbatim. A prefix here would push the
+          # conventional-commit type out of first position and fail the PR
+          # Title Check; the "backport" label marks these PRs instead.
+          pull_title: '${pull_title}'
           pull_description: |
             Automated backport of #${pull_number} to `${target_branch}`.
+          add_labels: backport
           # Carry the original PR's labels onto the backport PR, except the
           # "backport <branch>" label itself — copying it would re-trigger this
           # workflow when the generated PR is merged.


### PR DESCRIPTION
## Problem

`backport.yml` set:

```yaml
pull_title: '[Backport ${target_branch}] ${pull_title}'
```

The prefix pushes the conventional-commit type out of first position, so `amannn/action-semantic-pull-request` in **PR Title Check** cannot parse it. Every generated backport PR failed the check and needed a manual retitle.

## Fix

- `pull_title: '${pull_title}'` — reuse the source title verbatim. It is already conventional (the source PR passed the same check).
- `add_labels: backport` — the label carries the "this is a backport" signal that the title prefix used to. The `backport` label already exists in this repo.

This matches upstream frappe, which uses `title: "{{originalTitle}}"` plus `labelsToAdd: "backport"`.

## Notes

- `backport` (no space) does not match `label_pattern: '^backport ([^ ]+)$'`, so labelling the generated PR cannot re-trigger the workflow.
- Target branch is still visible in the PR body (`Automated backport of #N to \`branch\``) and in the generated branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)