### PR TITLE
fix: prefill "To" when composing email on proposal doctypes

### DIFF
--- a/buzz/proposals/doctype/event_proposal/event_proposal.js
+++ b/buzz/proposals/doctype/event_proposal/event_proposal.js
@@ -2,6 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Event Proposal", {
+	// Guest submissions leave owner as "Guest", so there is nothing to prefill.
+	get_email_recipients(frm, fieldname) {
+		const owner = frm.doc.owner || "";
+		return fieldname === "recipients" && owner.includes("@") ? [owner] : [];
+	},
+
 	refresh(frm) {
 		if (!frm.is_new() && frm.doc.docstatus == 0) {
 			frm.set_intro("Buzz Event will be created on submission of this document", "yellow");

--- a/buzz/proposals/doctype/sponsorship_enquiry/sponsorship_enquiry.js
+++ b/buzz/proposals/doctype/sponsorship_enquiry/sponsorship_enquiry.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Sponsorship Enquiry", {
+	get_email_recipients(frm, fieldname) {
+		const owner = frm.doc.owner || "";
+		return fieldname === "recipients" && owner.includes("@") ? [owner] : [];
+	},
+
 	setup(frm) {
 		frm.set_query("tier", (doc) => {
 			return {

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.js
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.js
@@ -2,6 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Talk Proposal", {
+	get_email_recipients(frm, fieldname) {
+		if (fieldname !== "recipients") {
+			return [];
+		}
+		return (frm.doc.speakers || []).map((speaker) => speaker.email).filter(Boolean);
+	},
+
 	refresh(frm) {
 		if (frm.doc.status != "Accepted") {
 			const btn = frm.add_custom_button(__("Accept and Create Talk"), () => {


### PR DESCRIPTION
Closes #246

Clicking "New Email" on a proposal doctype opened the composer with an empty "To" field.

Frappe's composer resolves the default recipient through the form's `get_email_recipients(frm, fieldname)` handler (`frappe/public/js/frappe/views/communication.js`), falling back to `frm.email_field` / `doc.email_id` / `doc.email`. The proposal doctypes define none of these, so nothing was prefilled.

Each doctype now defines the handler:

- **Talk Proposal** — every email in the `speakers` child table, the only place addresses are stored. `Proposal Speaker.email` is mandatory, so there is always at least one.
- **Event Proposal** — the submitting user. Guest submissions leave `owner` as `"Guest"`, which is skipped.
- **Sponsorship Enquiry** — the submitting user, matching the recipients the controller already notifies.

No schema changes, no patch, no migration.

Verified manually in desk: the composer opens with "To" populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)