### PR TITLE
refactor(api): add response schemas to the thin domains

### DIFF
--- a/buzz/api/account/__init__.py
+++ b/buzz/api/account/__init__.py
@@ -2,52 +2,55 @@ import frappe
 from frappe import _
 from frappe.translate import get_all_translations
 
+from buzz.api.account.schemas import GuestInfoResponse, LanguageOption, UserInfoResponse
+from buzz.api.exceptions import BuzzAPIError
+
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
-def get_user_info() -> dict:
+def get_user_info() -> UserInfoResponse | GuestInfoResponse:
 	if frappe.session.user == "Guest":
-		return {
-			"is_logged_in": False,
-			"brand_image": frappe.get_cached_value("Website Settings", "Website Settings", "banner_image"),
-		}
+		return GuestInfoResponse(
+			is_logged_in=False,
+			brand_image=frappe.get_cached_value("Website Settings", "Website Settings", "banner_image"),
+		)
 
 	user = frappe.get_cached_doc("User", frappe.session.user)
 
-	return {
-		"name": user.name,
-		"is_logged_in": True,
-		"first_name": user.first_name,
-		"last_name": user.last_name,
-		"full_name": user.full_name,
-		"email": user.email,
-		"user_image": user.user_image,
-		"roles": user.roles,
-		"brand_image": frappe.get_single_value("Website Settings", "banner_image"),
-		"language": user.language,
-	}
+	return UserInfoResponse(
+		name=user.name,
+		is_logged_in=True,
+		first_name=user.first_name,
+		last_name=user.last_name,
+		full_name=user.full_name,
+		email=user.email,
+		user_image=user.user_image,
+		roles=user.roles,
+		brand_image=frappe.get_single_value("Website Settings", "banner_image"),
+		language=user.language,
+	)
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
-def get_enabled_languages():
+def get_enabled_languages() -> list[LanguageOption]:
 	languages = frappe.get_all(
 		"Language",
 		filters={"enabled": 1},
 		fields=["name", "language_name", "language_code"],
 		order_by="language_name",
 	)
-	return languages
+	return [LanguageOption(**language) for language in languages]
 
 
 @frappe.whitelist()
-def update_user_language(language_code: str):
+def update_user_language(language_code: str) -> None:
 	if not frappe.db.exists("Language", {"language_code": language_code}):
-		frappe.throw(_("Invalid language"))
+		frappe.throw(_("Invalid language"), BuzzAPIError)
 
 	frappe.db.set_value("User", frappe.session.user, "language", language_code)
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
-def get_translations():
+def get_translations() -> dict:
 	if frappe.session.user != "Guest":
 		language = frappe.db.get_value("User", frappe.session.user, "language")
 	else:
@@ -56,5 +59,5 @@ def get_translations():
 	return get_all_translations(language)
 
 
-def has_app_permission():
+def has_app_permission() -> bool:
 	return True

--- a/buzz/api/account/__init__.py
+++ b/buzz/api/account/__init__.py
@@ -1,9 +1,8 @@
 import frappe
-from frappe import _
 from frappe.translate import get_all_translations
 
+from buzz.api.account.exceptions import UnknownLanguage
 from buzz.api.account.schemas import GuestInfoResponse, LanguageOption, UserInfoResponse
-from buzz.api.exceptions import BuzzAPIError
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
@@ -44,7 +43,7 @@ def get_enabled_languages() -> list[LanguageOption]:
 @frappe.whitelist()
 def update_user_language(language_code: str) -> None:
 	if not frappe.db.exists("Language", {"language_code": language_code}):
-		frappe.throw(_("Invalid language"), BuzzAPIError)
+		UnknownLanguage.throw(language_code=language_code)
 
 	frappe.db.set_value("User", frappe.session.user, "language", language_code)
 

--- a/buzz/api/account/exceptions.py
+++ b/buzz/api/account/exceptions.py
@@ -1,0 +1,8 @@
+from frappe import _lt
+
+from buzz.api.exceptions import BuzzAPIError
+
+
+class UnknownLanguage(BuzzAPIError):
+	title = _lt("Language Not Available")
+	message = _lt("{language_code} is not one of the languages enabled for this site.")

--- a/buzz/api/account/schemas.py
+++ b/buzz/api/account/schemas.py
@@ -1,0 +1,26 @@
+from buzz.api.schemas import APIResponse
+
+
+class GuestInfoResponse(APIResponse):
+	is_logged_in: bool
+	brand_image: str | None
+
+
+class UserInfoResponse(APIResponse):
+	name: str
+	is_logged_in: bool
+	first_name: str | None
+	last_name: str | None
+	full_name: str | None
+	email: str
+	user_image: str | None
+	# Rows of the User.roles child table, serialized as full documents.
+	roles: list
+	brand_image: str | None
+	language: str | None
+
+
+class LanguageOption(APIResponse):
+	name: str
+	language_name: str
+	language_code: str

--- a/buzz/api/account/test_account.py
+++ b/buzz/api/account/test_account.py
@@ -1,0 +1,70 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.account import get_enabled_languages, get_user_info, update_user_language
+from buzz.api.exceptions import BuzzAPIError
+
+
+class TestGetUserInfo(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_guest_payload_carries_only_two_keys(self):
+		frappe.set_user("Guest")
+		info = get_user_info().__json__()
+
+		self.assertEqual(set(info), {"is_logged_in", "brand_image"})
+		self.assertFalse(info["is_logged_in"])
+
+	def test_logged_in_payload_shape(self):
+		info = get_user_info().__json__()
+
+		self.assertEqual(
+			set(info),
+			{
+				"name",
+				"is_logged_in",
+				"first_name",
+				"last_name",
+				"full_name",
+				"email",
+				"user_image",
+				"roles",
+				"brand_image",
+				"language",
+			},
+		)
+		self.assertTrue(info["is_logged_in"])
+		self.assertEqual(info["name"], "Administrator")
+
+	def test_roles_stay_child_table_rows(self):
+		roles = get_user_info().__json__()["roles"]
+
+		self.assertTrue(roles)
+		self.assertTrue(any(row.role == "Administrator" for row in roles))
+
+
+class TestLanguages(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_enabled_languages_shape(self):
+		languages = [language.__json__() for language in get_enabled_languages()]
+
+		self.assertTrue(languages)
+		self.assertEqual(set(languages[0]), {"name", "language_name", "language_code"})
+
+	def test_update_rejects_unknown_language(self):
+		with self.assertRaises(BuzzAPIError):
+			update_user_language("not-a-language")
+
+	def test_unknown_language_maps_to_400(self):
+		self.assertEqual(BuzzAPIError.http_status_code, 400)
+
+	def test_update_persists_language(self):
+		original = frappe.db.get_value("User", "Administrator", "language")
+		self.addCleanup(frappe.db.set_value, "User", "Administrator", "language", original)
+
+		update_user_language("en")
+
+		self.assertEqual(frappe.db.get_value("User", "Administrator", "language"), "en")

--- a/buzz/api/account/test_account.py
+++ b/buzz/api/account/test_account.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from buzz.api.account import get_enabled_languages, get_user_info, update_user_language
-from buzz.api.exceptions import BuzzAPIError
+from buzz.api.account.exceptions import UnknownLanguage
 
 
 class TestGetUserInfo(IntegrationTestCase):
@@ -55,11 +55,17 @@ class TestLanguages(IntegrationTestCase):
 		self.assertEqual(set(languages[0]), {"name", "language_name", "language_code"})
 
 	def test_update_rejects_unknown_language(self):
-		with self.assertRaises(BuzzAPIError):
+		frappe.clear_messages()
+
+		with self.assertRaises(UnknownLanguage):
 			update_user_language("not-a-language")
 
+		message = frappe.local.message_log[-1]
+		self.assertEqual(message["title"], "Language Not Available")
+		self.assertIn("not-a-language", message["message"])
+
 	def test_unknown_language_maps_to_400(self):
-		self.assertEqual(BuzzAPIError.http_status_code, 400)
+		self.assertEqual(UnknownLanguage.http_status_code, 400)
 
 	def test_update_persists_language(self):
 		original = frappe.db.get_value("User", "Administrator", "language")

--- a/buzz/api/auth/__init__.py
+++ b/buzz/api/auth/__init__.py
@@ -1,38 +1,37 @@
 import frappe
-from frappe.utils import cint, md_to_html
+from frappe.utils import md_to_html
 from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
+
+from buzz.api.auth.schemas import LoginContextResponse, ProviderLogin
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
-def get_login_context(redirect_to: str | None = None):
-	context = {
-		"disable_signup": frappe.get_website_settings("disable_signup"),
-		"disable_user_pass_login": frappe.get_system_settings("disable_user_pass_login"),
-		"login_with_email_link": frappe.get_system_settings("login_with_email_link"),
-		"login_banner": md_to_html(raw_banner)
-		if (raw_banner := frappe.db.get_single_value("Buzz Settings", "login_banner"))
-		else None,
-		"provider_logins": [],
-	}
+def get_login_context(redirect_to: str | None = None) -> LoginContextResponse:
+	raw_banner = frappe.db.get_single_value("Buzz Settings", "login_banner")
 
-	if not redirect_to:
-		redirect_to = frappe.utils.get_url("/b")
+	return LoginContextResponse(
+		disable_signup=frappe.get_website_settings("disable_signup"),
+		disable_user_pass_login=frappe.get_system_settings("disable_user_pass_login"),
+		login_with_email_link=frappe.get_system_settings("login_with_email_link"),
+		login_banner=md_to_html(raw_banner) if raw_banner else None,
+		provider_logins=get_provider_logins(redirect_to or frappe.utils.get_url("/b")),
+	)
 
+
+def get_provider_logins(redirect_to: str) -> list[ProviderLogin]:
 	social_login_keys = frappe.get_all(
 		"Social Login Key",
 		filters={"enable_social_login": 1},
 		fields=["name", "provider_name", "icon", "client_id", "base_url"],
 	)
 
-	for provider in social_login_keys:
-		if provider.client_id and provider.base_url and get_oauth_keys(provider.name):
-			context["provider_logins"].append(
-				{
-					"name": provider.name,
-					"provider_name": provider.provider_name,
-					"icon": provider.icon or "",
-					"auth_url": get_oauth2_authorize_url(provider.name, redirect_to),
-				}
-			)
-
-	return context
+	return [
+		ProviderLogin(
+			name=provider.name,
+			provider_name=provider.provider_name,
+			icon=provider.icon or "",
+			auth_url=get_oauth2_authorize_url(provider.name, redirect_to),
+		)
+		for provider in social_login_keys
+		if provider.client_id and provider.base_url and get_oauth_keys(provider.name)
+	]

--- a/buzz/api/auth/schemas.py
+++ b/buzz/api/auth/schemas.py
@@ -1,0 +1,16 @@
+from buzz.api.schemas import APIResponse
+
+
+class ProviderLogin(APIResponse):
+	name: str
+	provider_name: str
+	icon: str
+	auth_url: str
+
+
+class LoginContextResponse(APIResponse):
+	disable_signup: int
+	disable_user_pass_login: int
+	login_with_email_link: int
+	login_banner: str | None
+	provider_logins: list[ProviderLogin]

--- a/buzz/api/auth/test_auth.py
+++ b/buzz/api/auth/test_auth.py
@@ -1,0 +1,43 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.auth import get_login_context
+
+
+class TestGetLoginContext(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_returns_expected_keys(self):
+		context = get_login_context().__json__()
+		self.assertEqual(
+			set(context),
+			{
+				"disable_signup",
+				"disable_user_pass_login",
+				"login_with_email_link",
+				"login_banner",
+				"provider_logins",
+			},
+		)
+
+	def test_settings_flags_stay_integers(self):
+		context = get_login_context().__json__()
+		for key in ("disable_signup", "disable_user_pass_login", "login_with_email_link"):
+			self.assertIsInstance(context[key], int)
+
+	def test_banner_is_rendered_as_html(self):
+		frappe.db.set_single_value("Buzz Settings", "login_banner", "# Welcome")
+		self.addCleanup(frappe.db.set_single_value, "Buzz Settings", "login_banner", None)
+
+		self.assertIn("<h1", get_login_context().__json__()["login_banner"])
+
+	def test_banner_is_none_when_unset(self):
+		frappe.db.set_single_value("Buzz Settings", "login_banner", None)
+
+		self.assertIsNone(get_login_context().__json__()["login_banner"])
+
+	def test_available_to_guest(self):
+		frappe.set_user("Guest")
+
+		self.assertIsInstance(get_login_context().__json__()["provider_logins"], list)

--- a/buzz/api/campaigns/__init__.py
+++ b/buzz/api/campaigns/__init__.py
@@ -1,60 +1,51 @@
 import frappe
 from frappe import _
 
+from buzz.api.campaigns.schemas import CampaignResponse
+from buzz.api.exceptions import Conflict
 from buzz.utils import is_app_installed
 
 
 @frappe.whitelist()
-def get_campaign_details(campaign: str):
-	if not frappe.db.exists("Buzz Campaign", campaign):
-		frappe.throw(_("Campaign not found"), frappe.DoesNotExistError)
-
-	campaign_doc = frappe.get_cached_doc("Buzz Campaign", campaign)
+def get_campaign_details(campaign: str) -> CampaignResponse:
+	campaign_doc = get_campaign(campaign)
 
 	if not campaign_doc.enabled:
-		frappe.throw(_("This campaign is not active"))
+		frappe.throw(_("This campaign is not active"), Conflict)
 
-	return {
-		"title": campaign_doc.title,
-		"description": campaign_doc.description,
-		"event": campaign_doc.event,
-	}
+	return CampaignResponse(
+		title=campaign_doc.title,
+		description=campaign_doc.description,
+		event=campaign_doc.event,
+	)
 
 
 @frappe.whitelist()
-def register_campaign_interest(campaign: str):
+def register_campaign_interest(campaign: str) -> None:
 	if frappe.session.user == "Guest":
-		frappe.throw(_("Please login to register your interest"))
+		frappe.throw(_("Please login to register your interest"), frappe.AuthenticationError)
 
 	if not is_app_installed("crm"):
 		frappe.throw(_("CRM integration is not available"))
 
+	campaign_doc = get_campaign(campaign)
+
+	if frappe.db.exists("CRM Lead", {"email": frappe.session.user, "buzz_campaign": campaign}):
+		frappe.throw(_("You have already registered for this campaign"), Conflict)
+
+	create_campaign_lead(campaign_doc)
+
+
+def get_campaign(campaign: str):
 	if not frappe.db.exists("Buzz Campaign", campaign):
 		frappe.throw(_("Campaign not found"), frappe.DoesNotExistError)
 
-	campaign_doc = frappe.get_cached_doc("Buzz Campaign", campaign)
+	return frappe.get_cached_doc("Buzz Campaign", campaign)
 
+
+def create_campaign_lead(campaign_doc) -> None:
 	user = frappe.get_cached_doc("User", frappe.session.user)
 	first_name = user.first_name or user.full_name or frappe.session.user.split("@")[0]
-
-	existing_lead = frappe.db.exists(
-		"CRM Lead",
-		{"email": frappe.session.user, "buzz_campaign": campaign},
-	)
-	if existing_lead:
-		frappe.throw(_("You have already registered for this campaign"))
-
-	ticket = None
-	if campaign_doc.event:
-		ticket = frappe.db.get_value(
-			"Event Ticket",
-			{
-				"attendee_email": frappe.session.user,
-				"event": campaign_doc.event,
-				"docstatus": 1,
-			},
-			"name",
-		)
 
 	lead = frappe.get_doc(
 		{
@@ -62,8 +53,19 @@ def register_campaign_interest(campaign: str):
 			"first_name": first_name,
 			"email": frappe.session.user,
 			"status": "New",
-			"buzz_campaign": campaign,
-			"event_ticket": ticket,
+			"buzz_campaign": campaign_doc.name,
+			"event_ticket": get_attendee_ticket(campaign_doc.event),
 		}
 	)
 	lead.insert(ignore_permissions=True)
+
+
+def get_attendee_ticket(event: str | None) -> str | None:
+	if not event:
+		return None
+
+	return frappe.db.get_value(
+		"Event Ticket",
+		{"attendee_email": frappe.session.user, "event": event, "docstatus": 1},
+		"name",
+	)

--- a/buzz/api/campaigns/__init__.py
+++ b/buzz/api/campaigns/__init__.py
@@ -1,8 +1,8 @@
 import frappe
 from frappe import _
 
+from buzz.api.campaigns.exceptions import AlreadyRegistered, CampaignNotActive, CRMNotAvailable
 from buzz.api.campaigns.schemas import CampaignResponse
-from buzz.api.exceptions import Conflict
 from buzz.utils import is_app_installed
 
 
@@ -11,7 +11,7 @@ def get_campaign_details(campaign: str) -> CampaignResponse:
 	campaign_doc = get_campaign(campaign)
 
 	if not campaign_doc.enabled:
-		frappe.throw(_("This campaign is not active"), Conflict)
+		CampaignNotActive.throw()
 
 	return CampaignResponse(
 		title=campaign_doc.title,
@@ -26,12 +26,12 @@ def register_campaign_interest(campaign: str) -> None:
 		frappe.throw(_("Please login to register your interest"), frappe.AuthenticationError)
 
 	if not is_app_installed("crm"):
-		frappe.throw(_("CRM integration is not available"))
+		CRMNotAvailable.throw()
 
 	campaign_doc = get_campaign(campaign)
 
 	if frappe.db.exists("CRM Lead", {"email": frappe.session.user, "buzz_campaign": campaign}):
-		frappe.throw(_("You have already registered for this campaign"), Conflict)
+		AlreadyRegistered.throw()
 
 	create_campaign_lead(campaign_doc)
 

--- a/buzz/api/campaigns/exceptions.py
+++ b/buzz/api/campaigns/exceptions.py
@@ -1,0 +1,20 @@
+from frappe import _lt
+
+from buzz.api.exceptions import BuzzAPIError, Conflict
+
+
+class CampaignNotActive(Conflict):
+	title = _lt("Campaign Closed")
+	message = _lt("This campaign is no longer accepting registrations.")
+
+
+class AlreadyRegistered(Conflict):
+	title = _lt("Already Registered")
+	message = _lt("You have already registered your interest in this campaign.")
+
+
+class CRMNotAvailable(BuzzAPIError):
+	# Deliberately 4xx: the CRM app being absent is a site configuration gap, and a 5xx would
+	# write an Error Log on every click.
+	title = _lt("Unavailable")
+	message = _lt("Campaign registration is not available right now.")

--- a/buzz/api/campaigns/schemas.py
+++ b/buzz/api/campaigns/schemas.py
@@ -1,0 +1,7 @@
+from buzz.api.schemas import APIResponse
+
+
+class CampaignResponse(APIResponse):
+	title: str
+	description: str | None
+	event: str | None

--- a/buzz/api/campaigns/test_campaigns.py
+++ b/buzz/api/campaigns/test_campaigns.py
@@ -1,0 +1,46 @@
+import unittest
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.campaigns import get_campaign_details
+from buzz.api.exceptions import Conflict
+from buzz.utils import is_app_installed
+
+
+def make_campaign(enabled: int = 1) -> str:
+	# Buzz Campaign uses autoname "prompt" -> name set explicitly.
+	campaign = frappe.new_doc("Buzz Campaign")
+	campaign.name = f"Campaign {frappe.generate_hash(length=6)}"
+	campaign.title = campaign.name
+	campaign.description = "Interest list for the next edition"
+	campaign.enabled = enabled
+	campaign.insert(ignore_permissions=True)
+	return campaign.name
+
+
+class TestCampaignErrors(IntegrationTestCase):
+	def test_unknown_campaign_raises_not_found(self):
+		with self.assertRaises(frappe.DoesNotExistError):
+			get_campaign_details("no-such-campaign")
+
+	def test_conflict_maps_to_409(self):
+		self.assertEqual(Conflict.http_status_code, 409)
+
+
+# Buzz Campaign refuses to save unless Frappe CRM is installed.
+@unittest.skipUnless(is_app_installed("crm"), "requires the crm app")
+class TestGetCampaignDetails(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_returns_expected_keys(self):
+		details = get_campaign_details(make_campaign()).__json__()
+
+		self.assertEqual(set(details), {"title", "description", "event"})
+
+	def test_disabled_campaign_raises_conflict(self):
+		campaign = make_campaign(enabled=0)
+
+		with self.assertRaises(Conflict):
+			get_campaign_details(campaign)

--- a/buzz/api/campaigns/test_campaigns.py
+++ b/buzz/api/campaigns/test_campaigns.py
@@ -4,7 +4,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from buzz.api.campaigns import get_campaign_details
-from buzz.api.exceptions import Conflict
+from buzz.api.campaigns.exceptions import AlreadyRegistered, CampaignNotActive, CRMNotAvailable
 from buzz.utils import is_app_installed
 
 
@@ -24,8 +24,15 @@ class TestCampaignErrors(IntegrationTestCase):
 		with self.assertRaises(frappe.DoesNotExistError):
 			get_campaign_details("no-such-campaign")
 
-	def test_conflict_maps_to_409(self):
-		self.assertEqual(Conflict.http_status_code, 409)
+	def test_status_codes(self):
+		self.assertEqual(CampaignNotActive.http_status_code, 409)
+		self.assertEqual(AlreadyRegistered.http_status_code, 409)
+		self.assertEqual(CRMNotAvailable.http_status_code, 400)
+
+	def test_each_error_carries_its_own_copy(self):
+		titles = {str(error.title) for error in (CampaignNotActive, AlreadyRegistered, CRMNotAvailable)}
+
+		self.assertEqual(len(titles), 3)
 
 
 # Buzz Campaign refuses to save unless Frappe CRM is installed.
@@ -39,8 +46,11 @@ class TestGetCampaignDetails(IntegrationTestCase):
 
 		self.assertEqual(set(details), {"title", "description", "event"})
 
-	def test_disabled_campaign_raises_conflict(self):
+	def test_disabled_campaign_reports_its_message(self):
 		campaign = make_campaign(enabled=0)
+		frappe.clear_messages()
 
-		with self.assertRaises(Conflict):
+		with self.assertRaises(CampaignNotActive):
 			get_campaign_details(campaign)
+
+		self.assertEqual(frappe.local.message_log[-1]["title"], "Campaign Closed")

--- a/buzz/api/proposals/__init__.py
+++ b/buzz/api/proposals/__init__.py
@@ -1,20 +1,10 @@
-from datetime import datetime
-
 import frappe
-from pydantic import BaseModel
 
-
-class ProposalListItem(BaseModel):
-	name: str
-	title: str
-	event: str
-	event_title: str | None = None
-	status: str
-	creation: datetime
+from buzz.api.proposals.schemas import ProposalListItem
 
 
 @frappe.whitelist()
-def get_my_proposals() -> list[dict]:
+def get_my_proposals() -> list[ProposalListItem]:
 	"""Proposals where the session user is the submitter or a listed speaker.
 
 	Speaker matching runs on the speakers child table because guest form
@@ -38,4 +28,4 @@ def get_my_proposals() -> list[dict]:
 		order_by="creation desc",
 	)
 
-	return [ProposalListItem(**row).model_dump() for row in rows]
+	return [ProposalListItem(**row) for row in rows]

--- a/buzz/api/proposals/schemas.py
+++ b/buzz/api/proposals/schemas.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from buzz.api.schemas import APIResponse
+
+
+class ProposalListItem(APIResponse):
+	name: str
+	title: str
+	event: str
+	event_title: str | None = None
+	status: str
+	creation: datetime

--- a/buzz/api/proposals/test_proposals.py
+++ b/buzz/api/proposals/test_proposals.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils.data import cstr
+from frappe.utils.response import json_handler
 
 from buzz.api.forms.test_forms import ensure_prompt_named_record
 from buzz.api.proposals import get_my_proposals
@@ -9,6 +10,10 @@ from buzz.proposals.doctype.talk_proposal.test_talk_proposal import (
 	make_test_event,
 	make_test_user,
 )
+
+
+def serialized_proposals() -> list[dict]:
+	return [proposal.__json__() for proposal in get_my_proposals()]
 
 
 class TestGetMyProposals(IntegrationTestCase):
@@ -27,7 +32,7 @@ class TestGetMyProposals(IntegrationTestCase):
 
 	def test_returns_guest_submitted_proposal_for_speaker(self):
 		frappe.set_user(self.speaker_user)
-		names = [row["name"] for row in get_my_proposals()]
+		names = [row["name"] for row in serialized_proposals()]
 		self.assertIn(self.guest_proposal, names)
 
 	def test_returns_proposal_submitted_by_user_without_speaker_row(self):
@@ -42,18 +47,22 @@ class TestGetMyProposals(IntegrationTestCase):
 		).insert(ignore_permissions=True)
 
 		frappe.set_user(self.speaker_user)
-		names = [row["name"] for row in get_my_proposals()]
+		names = [row["name"] for row in serialized_proposals()]
 		self.assertIn(proposal.name, names)
 
 	def test_excludes_unrelated_proposals(self):
 		frappe.set_user(self.other_user)
-		names = [row["name"] for row in get_my_proposals()]
+		names = [row["name"] for row in serialized_proposals()]
 		self.assertNotIn(self.guest_proposal, names)
 
 	def test_rows_have_expected_shape(self):
 		frappe.set_user(self.speaker_user)
-		row = next(r for r in get_my_proposals() if r["name"] == self.guest_proposal)
+		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
 		self.assertEqual(row["event"], cstr(self.event))
 		self.assertEqual(row["status"], "Review Pending")
-		for key in ("name", "title", "event_title", "creation"):
-			self.assertIn(key, row)
+		self.assertEqual(set(row), {"name", "title", "event", "event_title", "status", "creation"})
+
+	def test_creation_serializes_in_frappe_datetime_format(self):
+		frappe.set_user(self.speaker_user)
+		row = next(r for r in serialized_proposals() if r["name"] == self.guest_proposal)
+		self.assertRegex(json_handler(row["creation"]), r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")


### PR DESCRIPTION
Stacked on #295 — read that first. Diff here is only the four thin domains.

Endpoints now return pydantic models and throw named errors instead of hand-built dicts and generic 417s.

```python
def get_user_info() -> UserInfoResponse | GuestInfoResponse:
def get_enabled_languages() -> list[LanguageOption]:
def get_campaign_details(campaign: str) -> CampaignResponse:
def get_my_proposals() -> list[ProposalListItem]:
```

Three modelling calls, all made to keep the wire byte-identical:

- **`get_user_info` needs two models.** Guest gets 2 keys, logged-in user gets 10. One model with optionals would add `"name": null, "roles": null, …` to the guest payload.
- **Settings flags typed `int`, not `bool`.** They're Check fields travelling as `0`/`1`.
- **`roles` stays an untyped `list`.** It holds child-table documents that serialize as full docs.

Errors carry their own copy (base class is in #295):

```python
class AlreadyRegistered(Conflict):
    title = _lt("Already Registered")
    message = _lt("You have already registered your interest in this campaign.")

AlreadyRegistered.throw()
```

Two things I deliberately left alone:

- `CRMNotAvailable` is 400, not 5xx — `frappe/app.py:415` writes an Error Log for anything ≥ 500, and a missing app would log on every click.
- Login-required and campaign-not-found keep `frappe.AuthenticationError` / `frappe.DoesNotExistError`. Right status, clear message, wrapping adds nothing.
- `register_campaign_interest` still doesn't check `campaign.enabled` (only `get_campaign_details` does). Extracting a shared `get_campaign()` made adding it tempting; kept behaviour-neutral. Probably a real gap — separate call.

**Checks:** 22 tests green (2 campaign cases skip, `Buzz Campaign` won't insert without the `crm` app). Payloads captured before/after via `orjson_dumps(..., default=json_handler)` are byte-identical, including `datetime` as `2026-07-08 00:30:45.683135` rather than RFC-3339. `ruff` / `pre-commit` / full `bench run-tests --app buzz` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)