### PR TITLE
refactor(api): give check-in a service class and typed responses

### DIFF
--- a/buzz/api/checkin/__init__.py
+++ b/buzz/api/checkin/__init__.py
@@ -1,112 +1,14 @@
 import frappe
-from frappe import _
-from frappe.utils import format_date, format_time
+
+from buzz.api.checkin.schemas import CheckinResponse
+from buzz.api.checkin.services import CheckinService
 
 
 @frappe.whitelist()
-def validate_ticket_for_checkin(ticket_id: str) -> dict:
-	frappe.only_for("Frontdesk Manager", True)
-	if not frappe.db.exists("Event Ticket", ticket_id):
-		frappe.throw(_("Ticket not found"))
-
-	ticket_doc = frappe.get_cached_doc("Event Ticket", ticket_id)
-
-	if ticket_doc.docstatus == 2:
-		frappe.throw(_("This ticket has been cancelled and cannot be checked in"))
-
-	event_doc = frappe.get_cached_doc("Buzz Event", ticket_doc.event)
-	ticket_type_doc = (
-		frappe.get_cached_doc("Event Ticket Type", ticket_doc.ticket_type) if ticket_doc.ticket_type else None
-	)
-
-	checkin_date = frappe.utils.today()
-	existing_checkin = frappe.db.exists("Event Check In", {"ticket": ticket_id, "date": checkin_date})
-
-	if existing_checkin:
-		checkin_doc = frappe.get_doc("Event Check In", existing_checkin)
-		formatted_checkin_time = (
-			format_date(checkin_doc.creation) + " at " + format_time(checkin_doc.creation)
-		)
-
-		frappe.throw(_("This ticket was already checked in today ({0}).").format(formatted_checkin_time))
-
-	add_ons = frappe.db.get_all(
-		"Ticket Add-on Value",
-		filters={"parent": ticket_id},
-		fields=[
-			"add_on",
-			"add_on.title as add_on_title",
-			"add_on.user_selects_option as add_on_selects_option",
-			"value",
-			"price",
-			"currency",
-		],
-	)
-
-	return {
-		"message": _("Valid ticket ready for check-in"),
-		"ticket": {
-			"id": ticket_doc.name,
-			"attendee_name": ticket_doc.attendee_name,
-			"attendee_email": ticket_doc.attendee_email,
-			"event_title": event_doc.title,
-			"ticket_type": (ticket_type_doc.title if ticket_type_doc else ticket_doc.ticket_type),
-			"venue": event_doc.venue,
-			"start_date": event_doc.start_date,
-			"start_time": event_doc.start_time,
-			"end_date": event_doc.end_date,
-			"end_time": event_doc.end_time,
-			"is_checked_in": False,
-			"check_in_time": None,
-			"booking_id": ticket_doc.booking,
-			"add_ons": add_ons,
-		},
-		"payment_details": get_payment_details_for_ticket(ticket_id),
-	}
-
-
-def get_payment_details_for_ticket(ticket_id: str) -> dict | None:
-	booking_id = frappe.get_cached_value("Event Ticket", ticket_id, "booking")
-	if not booking_id:
-		return None
-
-	payments = frappe.db.get_all(
-		"Event Payment",
-		filters={
-			"reference_doctype": "Event Booking",
-			"reference_docname": booking_id,
-			"payment_received": 1,
-		},
-		fields=["name", "amount", "currency"],
-		limit=1,
-	)
-
-	if payments:
-		return payments[0]
+def validate_ticket_for_checkin(ticket_id: str) -> CheckinResponse:
+	return CheckinService(ticket_id).validate()
 
 
 @frappe.whitelist()
-def checkin_ticket(ticket_id: str) -> dict:
-	frappe.only_for("Frontdesk Manager", True)
-
-	checkin_date = frappe.utils.today()
-	validation_result = validate_ticket_for_checkin(ticket_id)
-
-	checkin_doc = frappe.new_doc("Event Check In")
-	checkin_doc.ticket = ticket_id
-	checkin_doc.date = checkin_date
-	checkin_doc.insert(ignore_permissions=True)
-	checkin_doc.submit()
-
-	return {
-		"message": _("Successfully checked in {attendee_name} for {checkin_date}").format(
-			attendee_name=validation_result["ticket"]["attendee_name"],
-			checkin_date=frappe.format(checkin_date, {"fieldtype": "Date"}),
-		),
-		"ticket": {
-			**validation_result["ticket"],
-			"is_checked_in": True,
-			"check_in_time": checkin_doc.creation,
-			"check_in_date": checkin_date,
-		},
-	}
+def checkin_ticket(ticket_id: str) -> CheckinResponse:
+	return CheckinService(ticket_id).checkin()

--- a/buzz/api/checkin/exceptions.py
+++ b/buzz/api/checkin/exceptions.py
@@ -1,0 +1,18 @@
+from frappe import _lt
+
+from buzz.api.exceptions import Conflict, ResourceNotFound
+
+
+class TicketNotFound(ResourceNotFound):
+	title = _lt("Ticket Not Found")
+	message = _lt("No ticket matches this code.")
+
+
+class TicketCancelled(Conflict):
+	title = _lt("Ticket Cancelled")
+	message = _lt("This ticket has been cancelled and cannot be checked in.")
+
+
+class AlreadyCheckedIn(Conflict):
+	title = _lt("Already Checked In")
+	message = _lt("This ticket was already checked in today, at {checked_in_at}.")

--- a/buzz/api/checkin/schemas.py
+++ b/buzz/api/checkin/schemas.py
@@ -1,0 +1,42 @@
+from datetime import date, datetime, timedelta
+
+from buzz.api.schemas import APIResponse
+
+
+class PaymentDetails(APIResponse):
+	name: str
+	amount: float
+	currency: str | None
+
+
+class TicketAddOn(APIResponse):
+	add_on: str
+	add_on_title: str | None
+	add_on_selects_option: int | None
+	value: str | None
+	price: float | None
+	currency: str | None
+
+
+class TicketCheckinDetails(APIResponse):
+	id: str
+	attendee_name: str | None
+	attendee_email: str | None
+	event_title: str
+	ticket_type: str | None
+	venue: str | None
+	start_date: date | None
+	start_time: timedelta | None
+	end_date: date | None
+	end_time: timedelta | None
+	is_checked_in: bool
+	check_in_time: datetime | None
+	booking_id: str | None
+	add_ons: list[TicketAddOn]
+	check_in_date: str | None = None
+
+
+class CheckinResponse(APIResponse):
+	message: str
+	ticket: TicketCheckinDetails
+	payment_details: PaymentDetails | None = None

--- a/buzz/api/checkin/services.py
+++ b/buzz/api/checkin/services.py
@@ -1,0 +1,131 @@
+from functools import cached_property
+
+import frappe
+from frappe import _
+from frappe.utils import format_date, format_time, today
+
+from buzz.api.checkin.exceptions import AlreadyCheckedIn, TicketCancelled, TicketNotFound
+from buzz.api.checkin.schemas import (
+	CheckinResponse,
+	PaymentDetails,
+	TicketAddOn,
+	TicketCheckinDetails,
+)
+
+CANCELLED = 2
+
+
+class CheckinService:
+	"""Front-desk check-in for a single ticket. Restricted to Frontdesk Manager."""
+
+	def __init__(self, ticket_id: str):
+		frappe.only_for("Frontdesk Manager", True)
+		self.ticket_id = ticket_id
+		self.date = today()
+
+	@cached_property
+	def ticket(self):
+		if not frappe.db.exists("Event Ticket", self.ticket_id):
+			TicketNotFound.throw()
+		return frappe.get_cached_doc("Event Ticket", self.ticket_id)
+
+	@cached_property
+	def event(self):
+		return frappe.get_cached_doc("Buzz Event", self.ticket.event)
+
+	def validate(self) -> CheckinResponse:
+		self.ensure_checkin_allowed()
+		return CheckinResponse(
+			message=_("Valid ticket ready for check-in"),
+			ticket=self.ticket_details(),
+			payment_details=self.payment_details(),
+		)
+
+	def checkin(self) -> CheckinResponse:
+		self.ensure_checkin_allowed()
+		checkin_doc = self.record_checkin()
+
+		return CheckinResponse(
+			message=_("Successfully checked in {attendee_name} for {checkin_date}").format(
+				attendee_name=self.ticket.attendee_name,
+				checkin_date=frappe.format(self.date, {"fieldtype": "Date"}),
+			),
+			ticket=self.ticket_details(
+				is_checked_in=True,
+				check_in_time=checkin_doc.creation,
+				check_in_date=self.date,
+			),
+		)
+
+	def ensure_checkin_allowed(self) -> None:
+		if self.ticket.docstatus == CANCELLED:
+			TicketCancelled.throw()
+
+		existing = frappe.db.exists("Event Check In", {"ticket": self.ticket_id, "date": self.date})
+		if existing:
+			creation = frappe.db.get_value("Event Check In", existing, "creation")
+			AlreadyCheckedIn.throw(checked_in_at=f"{format_date(creation)} at {format_time(creation)}")
+
+	def record_checkin(self):
+		checkin_doc = frappe.new_doc("Event Check In")
+		checkin_doc.ticket = self.ticket_id
+		checkin_doc.date = self.date
+		checkin_doc.insert(ignore_permissions=True)
+		checkin_doc.submit()
+		return checkin_doc
+
+	def ticket_details(self, **checkin_state) -> TicketCheckinDetails:
+		ticket_type = (
+			frappe.get_cached_value("Event Ticket Type", self.ticket.ticket_type, "title")
+			if self.ticket.ticket_type
+			else None
+		)
+
+		return TicketCheckinDetails(
+			id=self.ticket.name,
+			attendee_name=self.ticket.attendee_name,
+			attendee_email=self.ticket.attendee_email,
+			event_title=self.event.title,
+			ticket_type=ticket_type or self.ticket.ticket_type,
+			venue=self.event.venue,
+			start_date=self.event.start_date,
+			start_time=self.event.start_time,
+			end_date=self.event.end_date,
+			end_time=self.event.end_time,
+			is_checked_in=checkin_state.get("is_checked_in", False),
+			check_in_time=checkin_state.get("check_in_time"),
+			check_in_date=checkin_state.get("check_in_date"),
+			booking_id=self.ticket.booking,
+			add_ons=self.add_ons(),
+		)
+
+	def add_ons(self) -> list[TicketAddOn]:
+		rows = frappe.db.get_all(
+			"Ticket Add-on Value",
+			filters={"parent": self.ticket_id},
+			fields=[
+				"add_on",
+				"add_on.title as add_on_title",
+				"add_on.user_selects_option as add_on_selects_option",
+				"value",
+				"price",
+				"currency",
+			],
+		)
+		return [TicketAddOn(**row) for row in rows]
+
+	def payment_details(self) -> PaymentDetails | None:
+		if not self.ticket.booking:
+			return None
+
+		payments = frappe.db.get_all(
+			"Event Payment",
+			filters={
+				"reference_doctype": "Event Booking",
+				"reference_docname": self.ticket.booking,
+				"payment_received": 1,
+			},
+			fields=["name", "amount", "currency"],
+			limit=1,
+		)
+		return PaymentDetails(**payments[0]) if payments else None

--- a/buzz/api/checkin/services.py
+++ b/buzz/api/checkin/services.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import frappe
 from frappe import _
 from frappe.utils import format_date, format_time, today
@@ -9,6 +11,11 @@ from buzz.api.checkin.schemas import (
 	TicketAddOn,
 	TicketCheckinDetails,
 )
+
+if TYPE_CHECKING:
+	from buzz.events.doctype.buzz_event.buzz_event import BuzzEvent
+	from buzz.events.doctype.event_check_in.event_check_in import EventCheckIn
+	from buzz.ticketing.doctype.event_ticket.event_ticket import EventTicket
 
 CANCELLED = 2
 
@@ -25,11 +32,11 @@ class CheckinService:
 		self.date = today()
 
 	@property
-	def ticket(self):
+	def ticket(self) -> "EventTicket":
 		return frappe.get_cached_doc("Event Ticket", self.ticket_id)
 
 	@property
-	def event(self):
+	def event(self) -> "BuzzEvent":
 		return frappe.get_cached_doc("Buzz Event", self.ticket.event)
 
 	def validate(self) -> CheckinResponse:
@@ -65,7 +72,7 @@ class CheckinService:
 			creation = frappe.db.get_value("Event Check In", existing, "creation")
 			AlreadyCheckedIn.throw(checked_in_at=f"{format_date(creation)} at {format_time(creation)}")
 
-	def record_checkin(self):
+	def record_checkin(self) -> "EventCheckIn":
 		checkin_doc = frappe.new_doc("Event Check In")
 		checkin_doc.ticket = self.ticket_id
 		checkin_doc.date = self.date

--- a/buzz/api/checkin/services.py
+++ b/buzz/api/checkin/services.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 import frappe
 from frappe import _
 from frappe.utils import format_date, format_time, today
@@ -20,16 +18,17 @@ class CheckinService:
 
 	def __init__(self, ticket_id: str):
 		frappe.only_for("Frontdesk Manager", True)
+		if not frappe.db.exists("Event Ticket", ticket_id):
+			TicketNotFound.throw()
+
 		self.ticket_id = ticket_id
 		self.date = today()
 
-	@cached_property
+	@property
 	def ticket(self):
-		if not frappe.db.exists("Event Ticket", self.ticket_id):
-			TicketNotFound.throw()
 		return frappe.get_cached_doc("Event Ticket", self.ticket_id)
 
-	@cached_property
+	@property
 	def event(self):
 		return frappe.get_cached_doc("Buzz Event", self.ticket.event)
 

--- a/buzz/api/checkin/test_checkin.py
+++ b/buzz/api/checkin/test_checkin.py
@@ -1,0 +1,116 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from buzz.api.checkin import checkin_ticket, validate_ticket_for_checkin
+from buzz.api.checkin.exceptions import AlreadyCheckedIn, TicketCancelled, TicketNotFound
+from buzz.api.checkin.services import CheckinService
+
+TICKET_FIELDS = {
+	"id",
+	"attendee_name",
+	"attendee_email",
+	"event_title",
+	"ticket_type",
+	"venue",
+	"start_date",
+	"start_time",
+	"end_date",
+	"end_time",
+	"is_checked_in",
+	"check_in_time",
+	"check_in_date",
+	"booking_id",
+	"add_ons",
+}
+
+
+class CheckinTestCase(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.event = frappe.get_doc("Buzz Event", {"route": "test-route"}).name
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		frappe.clear_messages()
+
+		self.ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": self.event,
+				"title": f"Checkin Test {frappe.generate_hash(length=6)}",
+				"price": 0,
+			}
+		).insert()
+
+		self.ticket = frappe.get_doc(
+			{
+				"doctype": "Event Ticket",
+				"event": self.event,
+				"ticket_type": self.ticket_type.name,
+				"attendee_name": "Scanned Attendee",
+				"attendee_email": "scanned@example.com",
+			}
+		).insert()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+
+class TestValidateTicketForCheckin(CheckinTestCase):
+	def test_unknown_ticket_raises_not_found(self):
+		with self.assertRaises(TicketNotFound):
+			validate_ticket_for_checkin("no-such-ticket")
+
+		self.assertEqual(frappe.local.message_log[-1]["title"], "Ticket Not Found")
+
+	def test_status_codes(self):
+		self.assertEqual(TicketNotFound.http_status_code, 404)
+		self.assertEqual(TicketCancelled.http_status_code, 409)
+		self.assertEqual(AlreadyCheckedIn.http_status_code, 409)
+
+	def test_response_shape(self):
+		response = validate_ticket_for_checkin(self.ticket.name).__json__()
+
+		self.assertEqual(set(response), {"message", "ticket", "payment_details"})
+		self.assertEqual(set(response["ticket"]), TICKET_FIELDS)
+
+	def test_ticket_reads_as_not_checked_in(self):
+		ticket = validate_ticket_for_checkin(self.ticket.name).__json__()["ticket"]
+
+		self.assertEqual(ticket["id"], self.ticket.name)
+		self.assertFalse(ticket["is_checked_in"])
+		self.assertIsNone(ticket["check_in_time"])
+		self.assertIsNone(ticket["check_in_date"])
+
+	def test_cancelled_ticket_is_rejected(self):
+		service = CheckinService(self.ticket.name)
+		service.ticket.docstatus = 2
+
+		with self.assertRaises(TicketCancelled):
+			service.validate()
+
+
+class TestCheckinTicket(CheckinTestCase):
+	def test_checkin_records_and_reports(self):
+		response = checkin_ticket(self.ticket.name).__json__()
+
+		self.assertEqual(set(response["ticket"]), TICKET_FIELDS)
+		self.assertTrue(response["ticket"]["is_checked_in"])
+		self.assertIsNotNone(response["ticket"]["check_in_time"])
+		self.assertTrue(frappe.db.exists("Event Check In", {"ticket": self.ticket.name}))
+
+	def test_second_checkin_same_day_is_rejected(self):
+		checkin_ticket(self.ticket.name)
+		frappe.clear_messages()
+
+		with self.assertRaises(AlreadyCheckedIn):
+			checkin_ticket(self.ticket.name)
+
+		self.assertIn("already checked in today", frappe.local.message_log[-1]["message"])
+
+	def test_validation_rejects_an_already_checked_in_ticket(self):
+		checkin_ticket(self.ticket.name)
+
+		with self.assertRaises(AlreadyCheckedIn):
+			validate_ticket_for_checkin(self.ticket.name)

--- a/buzz/api/checkin/test_checkin.py
+++ b/buzz/api/checkin/test_checkin.py
@@ -3,7 +3,6 @@ from frappe.tests import IntegrationTestCase
 
 from buzz.api.checkin import checkin_ticket, validate_ticket_for_checkin
 from buzz.api.checkin.exceptions import AlreadyCheckedIn, TicketCancelled, TicketNotFound
-from buzz.api.checkin.services import CheckinService
 
 TICKET_FIELDS = {
 	"id",
@@ -84,11 +83,11 @@ class TestValidateTicketForCheckin(CheckinTestCase):
 		self.assertIsNone(ticket["check_in_date"])
 
 	def test_cancelled_ticket_is_rejected(self):
-		service = CheckinService(self.ticket.name)
-		service.ticket.docstatus = 2
+		frappe.db.set_value("Event Ticket", self.ticket.name, "docstatus", 2)
+		frappe.clear_document_cache("Event Ticket", self.ticket.name)
 
 		with self.assertRaises(TicketCancelled):
-			service.validate()
+			validate_ticket_for_checkin(self.ticket.name)
 
 
 class TestCheckinTicket(CheckinTestCase):

--- a/dashboard/src/components/QRScanner.vue
+++ b/dashboard/src/components/QRScanner.vue
@@ -74,6 +74,7 @@
 
 <script setup lang="ts">
 import { useTicketValidation } from "@/composables/useTicketValidation";
+import { extractTicketId } from "@/utils/ticketQr";
 import { Button, Spinner, TextInput, toast } from "frappe-ui";
 import { Html5Qrcode } from "html5-qrcode";
 import { onMounted, onUnmounted, ref } from "vue";
@@ -151,27 +152,6 @@ const onScanSuccess = (decodedText: string) => {
 	scanTimeout.value = setTimeout(() => {
 		lastScannedTicketId.value = null;
 	}, 2000);
-};
-
-const extractTicketId = (qrData: string) => {
-	// If QR contains just the ticket ID
-	if (qrData.match(/^[A-Z0-9\-]+$/)) {
-		return qrData;
-	}
-
-	// If QR contains a URL with ticket ID
-	const urlMatch = qrData.match(/ticket[\/=]([A-Z0-9\-]+)/i);
-	if (urlMatch) {
-		return urlMatch[1];
-	}
-
-	// Try to extract any alphanumeric string that looks like a ticket ID
-	const idMatch = qrData.match(/([A-Z0-9\-]{10,})/i);
-	if (idMatch) {
-		return idMatch[1];
-	}
-
-	return null;
 };
 
 const handleManualEntry = () => {

--- a/dashboard/src/composables/useTicketValidation.ts
+++ b/dashboard/src/composables/useTicketValidation.ts
@@ -102,27 +102,7 @@ const validateTicketResource = createResource({
 	onError: (error: any) => {
 		validationResult.value = null
 		isProcessingTicket.value = false
-		const errorData = JSON.stringify(error)
-
-		if (errorData.includes("Ticket not found")) {
-			showDebouncedToast("Ticket not found")
-		} else if (
-			errorData.includes(
-				"This ticket is not confirmed and cannot be used for check-in",
-			)
-		) {
-			showDebouncedToast(
-				"This ticket is not confirmed and cannot be used for check-in",
-			)
-		} else if (errorData.includes("This ticket was already checked in today")) {
-			showDebouncedToast("This ticket was already checked in today.")
-		} else if (errorData.includes("cancelled")) {
-			showDebouncedToast(
-				"This ticket has been cancelled and cannot be checked in",
-			)
-		} else {
-			showDebouncedToast("Error validating ticket")
-		}
+		showDebouncedToast(error?.messages?.[0] || __("Error validating ticket"))
 		playErrorSound()
 	},
 })
@@ -137,6 +117,8 @@ const checkInResource = createResource({
 	},
 	onError: (error: any) => {
 		isCheckingIn.value = false
+		showDebouncedToast(error?.messages?.[0] || __("Check-in failed"))
+		playErrorSound()
 	},
 })
 

--- a/dashboard/src/utils/ticketQr.test.ts
+++ b/dashboard/src/utils/ticketQr.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { extractTicketId } from "./ticketQr.ts";
+
+test("uppercase ticket id is returned as-is", () => {
+	assert.equal(extractTicketId("ABC123XYZ"), "ABC123XYZ");
+});
+
+test("lowercase frappe hash falls through to the length branch", () => {
+	// Only matches because frappe hashes are 10 characters; the first branch is uppercase-only.
+	assert.equal(extractTicketId("o3iuamhq0n"), "o3iuamhq0n");
+});
+
+test("ticket id is pulled out of a ticket url", () => {
+	assert.equal(extractTicketId("http://buzz.test:8000/b/ticket/o3iuamhq0n"), "o3iuamhq0n");
+});
+
+test("query-string form is also recognised", () => {
+	assert.equal(extractTicketId("https://buzz.test/scan?ticket=ABC123"), "ABC123");
+});
+
+test("short lowercase id without a ticket segment is not recognised", () => {
+	assert.equal(extractTicketId("abc123"), null);
+});
+
+test("payload with nothing ticket-shaped returns null", () => {
+	assert.equal(extractTicketId("hello there"), null);
+});

--- a/dashboard/src/utils/ticketQr.ts
+++ b/dashboard/src/utils/ticketQr.ts
@@ -1,0 +1,24 @@
+/**
+ * Pull a ticket ID out of a scanned QR payload, which may be the bare ID or a ticket URL.
+ * Returns null when nothing ticket-shaped is found.
+ */
+export function extractTicketId(qrData: string): string | null {
+	// If QR contains just the ticket ID
+	if (qrData.match(/^[A-Z0-9\-]+$/)) {
+		return qrData;
+	}
+
+	// If QR contains a URL with ticket ID
+	const urlMatch = qrData.match(/ticket[\/=]([A-Z0-9\-]+)/i);
+	if (urlMatch) {
+		return urlMatch[1];
+	}
+
+	// Try to extract any alphanumeric string that looks like a ticket ID
+	const idMatch = qrData.match(/([A-Z0-9\-]{10,})/i);
+	if (idMatch) {
+		return idMatch[1];
+	}
+
+	return null;
+}

--- a/e2e/data/check-in.ts
+++ b/e2e/data/check-in.ts
@@ -1,0 +1,17 @@
+// Shared between check-in.setup.ts and check-in.spec.ts. Playwright refuses to let a spec
+// import a setup file, so the seeded identifiers live here.
+
+export const CHECK_IN_EVENT_TITLE = "E2E Check-in Event";
+export const CHECK_IN_EVENT_ROUTE = "check-in-e2e";
+export const CHECK_IN_ATTENDEE_NAME = "Checkin Attendee";
+export const CHECK_IN_ATTENDEE_EMAIL = "checkin-attendee@buzz.test";
+
+export const FRONTDESK_EMAIL = "frontdesk-e2e@buzz.test";
+export const FRONTDESK_PASSWORD = "Frontdesk@123";
+export const FRONTDESK_STATE_PATH = "e2e/.auth/frontdesk.json";
+
+// A second identity, deliberately without the role. Administrator would not do: it holds every
+// role, so the access-denied path would never render for it.
+export const NO_ROLE_EMAIL = "no-frontdesk-e2e@buzz.test";
+export const NO_ROLE_PASSWORD = "NoFrontdesk@123";
+export const NO_ROLE_STATE_PATH = "e2e/.auth/no-frontdesk.json";

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,4 +1,7 @@
-import { APIRequestContext, BrowserContext, Page } from "@playwright/test";
+import { APIRequestContext, BrowserContext, Page, request as playwrightRequest } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+import { createDoc, docExists, updateDoc } from "./frappe";
 
 const STORAGE_STATE_PATH = "e2e/.auth/user.json";
 
@@ -62,6 +65,61 @@ export async function saveAuthState(context: BrowserContext): Promise<void> {
  */
 export function getStorageStatePath() {
 	return STORAGE_STATE_PATH;
+}
+
+/**
+ * Create a user holding the given roles, or top up the roles if they already exist.
+ * Returns the user's name (its email).
+ */
+export async function createUserWithRoles(
+	request: APIRequestContext,
+	options: { email: string; firstName: string; password: string; roles: string[] },
+): Promise<string> {
+	const { email, firstName, password, roles } = options;
+	const doc = {
+		first_name: firstName,
+		new_password: password,
+		send_welcome_email: 0,
+		enabled: 1,
+		roles: roles.map((role) => ({ role })),
+	};
+
+	if (await docExists(request, "User", email)) {
+		await updateDoc(request, "User", email, doc);
+		return email;
+	}
+
+	await createDoc(request, "User", { email, user_type: "System User", ...doc });
+	return email;
+}
+
+/**
+ * Log in as the given user in a throwaway context and persist the session to `statePath`,
+ * so a Playwright project can run under an identity other than the shared one.
+ */
+export async function saveLoginState(
+	baseURL: string,
+	options: { email: string; password: string; statePath: string },
+): Promise<void> {
+	const context = await playwrightRequest.newContext({ baseURL });
+	try {
+		await loginViaAPI(context, options.email, options.password);
+		fs.mkdirSync(path.dirname(options.statePath), { recursive: true });
+		await context.storageState({ path: options.statePath });
+	} finally {
+		await context.dispose();
+	}
+}
+
+/**
+ * API context under a saved session. Lets a spec running as one user read or assert as
+ * another — the shared Administrator state by default.
+ */
+export async function newApiContext(
+	baseURL: string,
+	statePath: string = STORAGE_STATE_PATH,
+): Promise<APIRequestContext> {
+	return playwrightRequest.newContext({ baseURL, storageState: statePath });
 }
 
 /**

--- a/e2e/pages/check-in.page.ts
+++ b/e2e/pages/check-in.page.ts
@@ -29,8 +29,17 @@ export class CheckInPage {
 		await this.checkButton.click();
 	}
 
+	/**
+	 * Clicks Check In and waits for the request to land. The "Last Scan Result" panel is not a
+	 * usable signal — it is already on screen from the preceding validate call.
+	 */
 	async confirmCheckIn(): Promise<void> {
+		const recorded = this.page.waitForResponse(
+			(response) => response.url().includes("checkin_ticket") && response.status() === 200,
+		);
 		await this.checkInButton.click();
+		await recorded;
+		await expect(this.ticketModal).toBeHidden();
 	}
 
 	async expectScannerVisible(): Promise<void> {

--- a/e2e/pages/check-in.page.ts
+++ b/e2e/pages/check-in.page.ts
@@ -1,0 +1,53 @@
+import { expect, Locator, Page } from "@playwright/test";
+
+export class CheckInPage {
+	private page: Page;
+	accessDeniedMessage: Locator;
+	manualTicketInput: Locator;
+	lastScanResult: Locator;
+	ticketModal: Locator;
+	private checkButton: Locator;
+	private checkInButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.accessDeniedMessage = page.getByText("Access Denied");
+		this.manualTicketInput = page.getByPlaceholder("Enter ticket ID manually");
+		this.checkButton = page.getByRole("button", { name: "Check", exact: true });
+		this.ticketModal = page.getByRole("dialog");
+		this.checkInButton = page.getByRole("button", { name: "Check In", exact: true });
+		this.lastScanResult = page.getByText("Last Scan Result");
+	}
+
+	async goto(eventName?: string): Promise<void> {
+		await this.page.goto(eventName ? `/b/check-in/${eventName}` : "/b/check-in");
+		await this.page.waitForLoadState("networkidle");
+	}
+
+	async submitTicketId(ticketId: string): Promise<void> {
+		await this.manualTicketInput.fill(ticketId);
+		await this.checkButton.click();
+	}
+
+	async confirmCheckIn(): Promise<void> {
+		await this.checkInButton.click();
+	}
+
+	async expectScannerVisible(): Promise<void> {
+		await expect(this.manualTicketInput).toBeVisible({ timeout: 15000 });
+		await expect(this.accessDeniedMessage).toBeHidden();
+	}
+
+	async expectAccessDenied(): Promise<void> {
+		await expect(this.accessDeniedMessage).toBeVisible({ timeout: 15000 });
+	}
+
+	async expectTicketModal(attendeeName: string): Promise<void> {
+		await expect(this.ticketModal).toBeVisible({ timeout: 15000 });
+		await expect(this.ticketModal.getByText(attendeeName)).toBeVisible();
+	}
+
+	async expectToast(message: string | RegExp): Promise<void> {
+		await expect(this.page.getByText(message).first()).toBeVisible({ timeout: 15000 });
+	}
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -2,3 +2,4 @@ export { LoginPage } from "./login.page";
 export { BookingPage } from "./booking.page";
 export { CustomFormPage } from "./custom-form.page";
 export { EventProposalPage } from "./event-proposal.page";
+export { CheckInPage } from "./check-in.page";

--- a/e2e/tests/check-in.setup.ts
+++ b/e2e/tests/check-in.setup.ts
@@ -1,9 +1,7 @@
-import { test as setup, expect } from "@playwright/test";
+import { test as setup } from "@playwright/test";
 import { createUserWithRoles, saveLoginState } from "../helpers/auth";
 import { callMethod, createDoc, deleteDoc, docExists, getList } from "../helpers/frappe";
 import {
-	CHECK_IN_ATTENDEE_EMAIL,
-	CHECK_IN_ATTENDEE_NAME,
 	CHECK_IN_EVENT_ROUTE,
 	CHECK_IN_EVENT_TITLE,
 	FRONTDESK_EMAIL,
@@ -61,7 +59,7 @@ async function cleanUpPreviousRun(request) {
 	}
 }
 
-setup("seed check-in event, ticket and front-desk user", async ({ request, baseURL }) => {
+setup("seed check-in event, ticket type and front-desk users", async ({ request, baseURL }) => {
 	await cleanUpPreviousRun(request);
 
 	if (!(await docExists(request, "Event Category", CATEGORY))) {
@@ -99,14 +97,6 @@ setup("seed check-in event, ticket and front-desk user", async ({ request, baseU
 		is_published: 1,
 	});
 
-	const ticket = await createDoc<NamedDoc>(request, "Event Ticket", {
-		event: event.name,
-		ticket_type: ticketType.name,
-		attendee_name: CHECK_IN_ATTENDEE_NAME,
-		attendee_email: CHECK_IN_ATTENDEE_EMAIL,
-	});
-	expect(ticket.name).toBeTruthy();
-
 	await createUserWithRoles(request, {
 		email: FRONTDESK_EMAIL,
 		firstName: "Frontdesk",
@@ -133,5 +123,5 @@ setup("seed check-in event, ticket and front-desk user", async ({ request, baseU
 		statePath: NO_ROLE_STATE_PATH,
 	});
 
-	console.log(`Check-in setup complete. Event ${event.name}, ticket ${ticket.name}`);
+	console.log(`Check-in setup complete. Event ${event.name}, ticket type ${ticketType.name}`);
 });

--- a/e2e/tests/check-in.setup.ts
+++ b/e2e/tests/check-in.setup.ts
@@ -1,0 +1,137 @@
+import { test as setup, expect } from "@playwright/test";
+import { createUserWithRoles, saveLoginState } from "../helpers/auth";
+import { callMethod, createDoc, deleteDoc, docExists, getList } from "../helpers/frappe";
+import {
+	CHECK_IN_ATTENDEE_EMAIL,
+	CHECK_IN_ATTENDEE_NAME,
+	CHECK_IN_EVENT_ROUTE,
+	CHECK_IN_EVENT_TITLE,
+	FRONTDESK_EMAIL,
+	FRONTDESK_PASSWORD,
+	FRONTDESK_STATE_PATH,
+	NO_ROLE_EMAIL,
+	NO_ROLE_PASSWORD,
+	NO_ROLE_STATE_PATH,
+} from "../data/check-in";
+
+interface NamedDoc {
+	name: string;
+}
+
+const CATEGORY = "E2E Check-in Category";
+const HOST = "E2E Check-in Host";
+
+// Cancel-then-delete: Event Ticket and Event Check In are submittable.
+async function forceDelete(request, doctype: string, name: string) {
+	await callMethod(request, "frappe.client.cancel", { doctype, name }).catch(() => {});
+	await deleteDoc(request, doctype, name).catch(() => {});
+}
+
+// Cleanup runs here rather than in the spec's afterAll: the spec runs under the front-desk
+// storage state, and the helpers sign their writes with the Administrator CSRF token.
+async function cleanUpPreviousRun(request) {
+	const events = await getList<NamedDoc>(request, "Buzz Event", {
+		filters: { title: ["=", CHECK_IN_EVENT_TITLE] },
+	});
+
+	for (const event of events) {
+		const tickets = await getList<NamedDoc>(request, "Event Ticket", {
+			filters: { event: ["=", event.name] },
+		});
+		for (const ticket of tickets) {
+			const checkIns = await getList<NamedDoc>(request, "Event Check In", {
+				filters: { ticket: ["=", ticket.name] },
+			});
+			for (const checkIn of checkIns) {
+				await forceDelete(request, "Event Check In", checkIn.name);
+			}
+			await forceDelete(request, "Event Ticket", ticket.name);
+		}
+
+		for (const doctype of ["Sponsorship Tier", "Event Ticket Type", "Ticket Add-on"]) {
+			const rows = await getList<NamedDoc>(request, doctype, {
+				filters: { event: ["=", event.name] },
+			});
+			for (const row of rows) {
+				await deleteDoc(request, doctype, row.name).catch(() => {});
+			}
+		}
+
+		await deleteDoc(request, "Buzz Event", event.name).catch(() => {});
+	}
+}
+
+setup("seed check-in event, ticket and front-desk user", async ({ request, baseURL }) => {
+	await cleanUpPreviousRun(request);
+
+	if (!(await docExists(request, "Event Category", CATEGORY))) {
+		await createDoc(request, "Event Category", {
+			name: CATEGORY,
+			enabled: 1,
+			slug: "e2e-check-in-category",
+		});
+	}
+
+	if (!(await docExists(request, "Event Host", HOST))) {
+		await createDoc(request, "Event Host", { name: HOST });
+	}
+
+	const startDate = new Date();
+	startDate.setDate(startDate.getDate() + 7);
+
+	const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+		title: CHECK_IN_EVENT_TITLE,
+		category: CATEGORY,
+		host: HOST,
+		route: CHECK_IN_EVENT_ROUTE,
+		start_date: startDate.toISOString().split("T")[0],
+		start_time: "09:00:00",
+		end_time: "17:00:00",
+		medium: "In Person",
+		is_published: 1,
+	});
+
+	const ticketType = await createDoc<NamedDoc>(request, "Event Ticket Type", {
+		event: event.name,
+		title: "Check-in Ticket",
+		price: 0,
+		currency: "INR",
+		is_published: 1,
+	});
+
+	const ticket = await createDoc<NamedDoc>(request, "Event Ticket", {
+		event: event.name,
+		ticket_type: ticketType.name,
+		attendee_name: CHECK_IN_ATTENDEE_NAME,
+		attendee_email: CHECK_IN_ATTENDEE_EMAIL,
+	});
+	expect(ticket.name).toBeTruthy();
+
+	await createUserWithRoles(request, {
+		email: FRONTDESK_EMAIL,
+		firstName: "Frontdesk",
+		password: FRONTDESK_PASSWORD,
+		roles: ["Buzz User", "Frontdesk Manager"],
+	});
+
+	await saveLoginState(baseURL!, {
+		email: FRONTDESK_EMAIL,
+		password: FRONTDESK_PASSWORD,
+		statePath: FRONTDESK_STATE_PATH,
+	});
+
+	await createUserWithRoles(request, {
+		email: NO_ROLE_EMAIL,
+		firstName: "No Frontdesk",
+		password: NO_ROLE_PASSWORD,
+		roles: ["Buzz User"],
+	});
+
+	await saveLoginState(baseURL!, {
+		email: NO_ROLE_EMAIL,
+		password: NO_ROLE_PASSWORD,
+		statePath: NO_ROLE_STATE_PATH,
+	});
+
+	console.log(`Check-in setup complete. Event ${event.name}, ticket ${ticket.name}`);
+});

--- a/e2e/tests/check-in.spec.ts
+++ b/e2e/tests/check-in.spec.ts
@@ -1,0 +1,97 @@
+import { APIRequestContext, expect, test } from "@playwright/test";
+import { getList, newApiContext } from "../helpers";
+import { CheckInPage } from "../pages";
+import {
+	CHECK_IN_ATTENDEE_EMAIL,
+	CHECK_IN_ATTENDEE_NAME,
+	CHECK_IN_EVENT_ROUTE,
+	NO_ROLE_STATE_PATH,
+} from "../data/check-in";
+
+interface NamedDoc {
+	name: string;
+}
+
+let admin: APIRequestContext;
+let eventName: string;
+let ticketId: string;
+
+test.beforeAll(async ({ baseURL }) => {
+	admin = await newApiContext(baseURL!);
+
+	const events = await getList<NamedDoc>(admin, "Buzz Event", {
+		filters: { route: ["=", CHECK_IN_EVENT_ROUTE] },
+	});
+	expect(events.length).toBeGreaterThan(0);
+	eventName = events[0].name;
+
+	const tickets = await getList<NamedDoc>(admin, "Event Ticket", {
+		filters: { attendee_email: ["=", CHECK_IN_ATTENDEE_EMAIL] },
+	});
+	expect(tickets.length).toBeGreaterThan(0);
+	ticketId = tickets[0].name;
+});
+
+test.afterAll(async () => {
+	await admin?.dispose();
+});
+
+test.describe("Check-in scanner", () => {
+	test("front-desk user reaches the scanner", async ({ page }) => {
+		const checkInPage = new CheckInPage(page);
+		await checkInPage.goto(eventName);
+
+		await checkInPage.expectScannerVisible();
+	});
+
+	test("a valid ticket opens the details modal", async ({ page }) => {
+		const checkInPage = new CheckInPage(page);
+		await checkInPage.goto(eventName);
+		await checkInPage.expectScannerVisible();
+
+		await checkInPage.submitTicketId(ticketId);
+
+		await checkInPage.expectTicketModal(CHECK_IN_ATTENDEE_NAME);
+	});
+
+	test("an unknown ticket surfaces the server message", async ({ page }) => {
+		const checkInPage = new CheckInPage(page);
+		await checkInPage.goto(eventName);
+		await checkInPage.expectScannerVisible();
+
+		await checkInPage.submitTicketId("NOSUCHTICKET");
+
+		await checkInPage.expectToast(/No ticket matches this code/i);
+	});
+
+	// Ordered last: it consumes the seeded ticket for the day.
+	test("checking in records the visit, and a second scan is refused", async ({ page }) => {
+		const checkInPage = new CheckInPage(page);
+		await checkInPage.goto(eventName);
+		await checkInPage.expectScannerVisible();
+
+		await checkInPage.submitTicketId(ticketId);
+		await checkInPage.expectTicketModal(CHECK_IN_ATTENDEE_NAME);
+		await checkInPage.confirmCheckIn();
+
+		await expect(checkInPage.lastScanResult).toBeVisible({ timeout: 15000 });
+		const checkIns = await getList<NamedDoc>(admin, "Event Check In", {
+			filters: { ticket: ["=", ticketId] },
+		});
+		expect(checkIns.length).toBe(1);
+
+		await checkInPage.submitTicketId(ticketId);
+		await checkInPage.expectToast(/already checked in today/i);
+	});
+});
+
+test.describe("Check-in access control", () => {
+	test.use({ storageState: NO_ROLE_STATE_PATH });
+
+	test("a user without the Frontdesk Manager role is refused", async ({ page }) => {
+		const checkInPage = new CheckInPage(page);
+		await checkInPage.goto();
+
+		await checkInPage.expectAccessDenied();
+	});
+});

--- a/e2e/tests/check-in.spec.ts
+++ b/e2e/tests/check-in.spec.ts
@@ -1,5 +1,5 @@
 import { APIRequestContext, expect, test } from "@playwright/test";
-import { getList, newApiContext } from "../helpers";
+import { createDoc, getList, newApiContext } from "../helpers";
 import { CheckInPage } from "../pages";
 import {
 	CHECK_IN_ATTENDEE_EMAIL,
@@ -14,7 +14,20 @@ interface NamedDoc {
 
 let admin: APIRequestContext;
 let eventName: string;
+let ticketType: string;
 let ticketId: string;
+
+// A fresh ticket per test: checking one in is not undoable within a run, so sharing would
+// leave a retry scanning an already-used ticket.
+async function createTicket(): Promise<string> {
+	const ticket = await createDoc<NamedDoc>(admin, "Event Ticket", {
+		event: eventName,
+		ticket_type: ticketType,
+		attendee_name: CHECK_IN_ATTENDEE_NAME,
+		attendee_email: CHECK_IN_ATTENDEE_EMAIL,
+	});
+	return ticket.name;
+}
 
 test.beforeAll(async ({ baseURL }) => {
 	admin = await newApiContext(baseURL!);
@@ -25,11 +38,15 @@ test.beforeAll(async ({ baseURL }) => {
 	expect(events.length).toBeGreaterThan(0);
 	eventName = events[0].name;
 
-	const tickets = await getList<NamedDoc>(admin, "Event Ticket", {
-		filters: { attendee_email: ["=", CHECK_IN_ATTENDEE_EMAIL] },
+	const ticketTypes = await getList<NamedDoc>(admin, "Event Ticket Type", {
+		filters: { event: ["=", eventName] },
 	});
-	expect(tickets.length).toBeGreaterThan(0);
-	ticketId = tickets[0].name;
+	expect(ticketTypes.length).toBeGreaterThan(0);
+	ticketType = ticketTypes[0].name;
+});
+
+test.beforeEach(async () => {
+	ticketId = await createTicket();
 });
 
 test.afterAll(async () => {
@@ -64,8 +81,7 @@ test.describe("Check-in scanner", () => {
 		await checkInPage.expectToast(/No ticket matches this code/i);
 	});
 
-	// Ordered last: it consumes the seeded ticket for the day.
-	test("checking in records the visit, and a second scan is refused", async ({ page }) => {
+	test("checking in records the visit", async ({ page }) => {
 		const checkInPage = new CheckInPage(page);
 		await checkInPage.goto(eventName);
 		await checkInPage.expectScannerVisible();
@@ -74,13 +90,23 @@ test.describe("Check-in scanner", () => {
 		await checkInPage.expectTicketModal(CHECK_IN_ATTENDEE_NAME);
 		await checkInPage.confirmCheckIn();
 
-		await expect(checkInPage.lastScanResult).toBeVisible({ timeout: 15000 });
 		const checkIns = await getList<NamedDoc>(admin, "Event Check In", {
 			filters: { ticket: ["=", ticketId] },
 		});
 		expect(checkIns.length).toBe(1);
+	});
+
+	test("a second scan the same day is refused", async ({ page }) => {
+		const checkInPage = new CheckInPage(page);
+		await checkInPage.goto(eventName);
+		await checkInPage.expectScannerVisible();
 
 		await checkInPage.submitTicketId(ticketId);
+		await checkInPage.expectTicketModal(CHECK_IN_ATTENDEE_NAME);
+		await checkInPage.confirmCheckIn();
+
+		await checkInPage.submitTicketId(ticketId);
+
 		await checkInPage.expectToast(/already checked in today/i);
 	});
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 // Auth state file path (added to .gitignore)
 const authFile = "e2e/.auth/user.json";
+const frontdeskFile = "e2e/.auth/frontdesk.json";
 
 /**
  * Playwright configuration for Buzz E2E tests.
@@ -61,7 +62,7 @@ export default defineConfig({
 		},
 		{
 			name: "chromium",
-			testIgnore: /guest-booking|custom-forms|event-proposal|login-modal/,
+			testIgnore: /guest-booking|custom-forms|event-proposal|login-modal|check-in/,
 			use: {
 				...devices["Desktop Chrome"],
 				storageState: authFile,
@@ -117,6 +118,23 @@ export default defineConfig({
 				storageState: authFile,
 			},
 			dependencies: ["event-proposal-setup"],
+		},
+		{
+			name: "check-in-setup",
+			testMatch: /check-in\.setup\.ts/,
+			use: {
+				storageState: authFile,
+			},
+			dependencies: ["setup"],
+		},
+		{
+			name: "check-in-chromium",
+			testMatch: /check-in\.spec\.ts/,
+			use: {
+				...devices["Desktop Chrome"],
+				storageState: frontdeskFile,
+			},
+			dependencies: ["check-in-setup"],
 		},
 		{
 			name: "offline-payment-setup",


### PR DESCRIPTION
Stacked on #296 — read that first. Diff here is `checkin/` plus its scanner composable.

Both endpoints are two lines now; `CheckinService` owns the Frontdesk Manager guard, the ticket lookup and the cancelled / already-checked-in checks. `checkin_ticket` no longer calls `validate_ticket_for_checkin` just to reuse them.

Errors replace three generic 417s: `TicketNotFound` (404), `TicketCancelled` and `AlreadyCheckedIn` (409), each with its own copy.

**The scanner was matching on error substrings.** `useTicketValidation.ts` picked its toast by `JSON.stringify(error).includes("Ticket not found")` and friends — so the error text was an undeclared contract, and changing any message would have silently broken it. Now reads `err.messages[0]` like the rest of the dashboard. One branch was already dead: nothing in Python throws "not confirmed and cannot be used for check-in".

**One intentional wire change:** `check_in_date` is now always present, `null` before check-in, where it used to be absent. `useTicketValidation.ts:20` already declared it `check_in_date?: string | null`. Same for `payment_details` on the check-in response — `TicketDetailsModal.vue:85` guards it with `v-if`. Everything else byte-identical, key order included; diffed old vs new module in-process.

Schema field types match what Frappe actually returns — `date`, `timedelta`, `datetime` — so `json_handler` renders them exactly as before (`"10:00:00"`, not RFC-3339).

**Checks:** 8 new tests, green. Full `bench run-tests --app buzz`, `ruff`, `pre-commit`, `yarn typecheck` clean.

**Noticed, not fixed:** only `docstatus == 2` blocks check-in, so a draft ticket still scans through. Pre-existing; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)