### PR TITLE
refactor(api): enforce type annotations on whitelisted methods

### DIFF
--- a/buzz/events/doctype/buzz_event/buzz_event.py
+++ b/buzz/events/doctype/buzz_event/buzz_event.py
@@ -193,7 +193,6 @@ class BuzzEvent(Document):
 					title=frappe._("Email Not Configured"),
 				)
 
-	@frappe.whitelist()
 	def after_insert(self):
 		self.create_default_records()
 

--- a/buzz/hooks.py
+++ b/buzz/hooks.py
@@ -12,6 +12,9 @@ required_apps = ["frappe/payments"]
 
 export_python_type_annotations = True
 
+# Require all whitelisted methods to have type annotations
+require_type_annotated_api_methods = True
+
 after_install = "buzz.install.after_install"
 
 before_uninstall = "buzz.uninstall.before_uninstall"

--- a/buzz/payments.py
+++ b/buzz/payments.py
@@ -126,8 +126,6 @@ def mark_payment_as_received(reference_doctype: str, reference_docname: str):
 	if frappe.in_test:
 		return
 
-	import json
-
 	request = frappe.get_all(
 		"Integration Request",
 		{
@@ -140,7 +138,7 @@ def mark_payment_as_received(reference_doctype: str, reference_docname: str):
 
 	if len(request):
 		data = frappe.db.get_value("Integration Request", request[0].name, "data")
-		data = frappe._dict(json.loads(data))
+		data = frappe.parse_json(data)
 
 		payment_gateway = data.get("payment_gateway")
 		if payment_gateway == "Razorpay":

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2025, BWH Studios and contributors
 # For license information, please see license.txt
-import json
-
 import frappe
 from frappe import _
 from frappe.email.doctype.email_template.email_template import get_email_template
@@ -288,8 +286,8 @@ class EventBooking(Document):
 				custom_fields_data = attendee.custom_fields
 				if isinstance(custom_fields_data, str):
 					try:
-						custom_fields_data = json.loads(custom_fields_data)
-					except (json.JSONDecodeError, TypeError):
+						custom_fields_data = frappe.parse_json(custom_fields_data)
+					except (ValueError, TypeError):
 						custom_fields_data = {}
 
 				# Get custom field definitions for this event to get proper labels and types


### PR DESCRIPTION
Stacked on #302 — read that first.

Turns on `require_type_annotated_api_methods` for buzz, the last step of the API
refactor, plus the dead surface the plan parked here.

The plan expected this PR to annotate eight whitelisted controller methods. It
annotates none: `typing_validations.py:114-115` skips the first parameter when it
is `self`/`cls`, and every one of those methods takes only `self`. The two
module-level ones were already typed. An AST pass and a live `frappe.whitelisted`
walk both found zero unannotated arguments, so the hook flip is inert on today's
code — which is the point.

- **CI already blocks this statically.** `frappe/semgrep-rules`'
  `missing-argument-type-hint` (`rules/security/whitelisted.yml`) is inside the path
  `linter.yml:38-41` already scans. Verified: it catches an unannotated argument
  plain, behind an intervening decorator, and alongside `*args/**kwargs`, and
  `semgrep ci` exits 1 with the findings marked blocking. The hook is the runtime
  half — it sees what a syntactic rule cannot, and `# nosemgrep` doesn't silence it.
  A test asserting the same thing was written and then dropped as redundant.
- The hook resolves **per the defining function's app** (`typing_validations.py:31,44`
  splits `func.__module__`), so setting it in `buzz/hooks.py` binds `buzz.*` only.
  It checks argument presence, never return annotations, and skips `*args`/`**kwargs`.
- It fires inside the `frappe.whitelist` wrapper at **call** time
  (`frappe/__init__.py:609`, `apply_condition=_in_request_or_test`), so it is inert
  outside a request or test.
- `BuzzEvent.after_insert` loses its whitelist — it made a lifecycle hook re-runnable
  via `run_doc_method`, duplicating default tiers and ticket types.
- `frappe.parse_json` already returns a `frappe._dict` (`frappe/utils/data.py:2661`),
  so `payments.py` collapses to one call. `orjson.JSONDecodeError` subclasses
  `json.JSONDecodeError`, so widening `event_booking.py`'s except to `ValueError` is
  a no-op that lets the `json` import go.
- Deliberate non-change: `payments.mark_payment_as_received` early-returns on
  `frappe.in_test` (`payments.py:126`), so its `parse_json` swap has no test. Making
  that path testable is #299.
- The plan's fourth item, a commented `buzz.api.download_ticket` block in
  `TicketDetails.vue`, was already gone.

**Checks:** 354 Python tests green (`run-tests --app buzz`, 2 crm-gated skips); ruff
check and format clean; semgrep clean; Playwright 81/85 locally, the 4 failures
reproduced identically with this PR stashed (2 are the known guest-OTP
`frappe.in_test` gap, 2 are UI-login specs Harsh asked to ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
