### PR TITLE
ci: share a bench setup action and stop evicting the browser cache

### DIFF
--- a/.github/actions/setup-bench/action.yml
+++ b/.github/actions/setup-bench/action.yml
@@ -1,0 +1,146 @@
+name: "Setup Bench"
+description: "Provisions a bench with buzz installed on a fresh site"
+
+inputs:
+  site-name:
+    description: "Site to create. Also used as the /etc/hosts entry and host_name."
+    required: false
+    default: "test_site"
+  build-assets:
+    description: "Run `bench build`. Only needed by jobs that hit the UI."
+    required: false
+    default: "false"
+  extra-app-url:
+    description: "Git URL of one more app to install before buzz. App name is the last path segment."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Add site to hosts
+      shell: bash -e {0}
+      run: echo "127.0.0.1 ${{ inputs.site-name }}" | sudo tee -a /etc/hosts
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.14"
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "24"
+        cache: yarn
+        cache-dependency-path: dashboard/yarn.lock
+
+    - uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          **/pyproject.toml
+          **/requirements*.txt
+
+    - name: Install system deps and bench
+      shell: bash -e {0}
+      run: |
+        install_db_client() {
+          # `apt-get update` is most of the cost, so only pay for it if the
+          # runner's package lists are too stale to resolve.
+          sudo apt-get -qq install -y --no-install-recommends mariadb-client \
+            || { sudo apt-get -qq update \
+                 && sudo apt-get -qq install -y --no-install-recommends mariadb-client; }
+        }
+
+        # apt and uv share no inputs.
+        install_db_client &> "${RUNNER_TEMP}/apt.log" &
+        apt_pid=$!
+
+        uv tool install frappe-bench
+
+        if ! wait "$apt_pid"; then
+          cat "${RUNNER_TEMP}/apt.log"
+          exit 1
+        fi
+
+    - name: Init bench
+      shell: bash -e {0}
+      run: |
+        bench init ~/frappe-bench \
+          --skip-redis-config-generation \
+          --skip-assets \
+          --no-backups \
+          --python "$(which python)"
+
+        cd ~/frappe-bench
+
+        # socketio stays: the dashboard opens a socket on boot (dashboard/src/main.ts).
+        sed -i '/^watch:/d;/^schedule:/d' Procfile
+
+    - name: Get apps
+      shell: bash -e {0}
+      working-directory: /home/runner/frappe-bench
+      env:
+        EXTRA_APP_URL: ${{ inputs.extra-app-url }}
+      run: |
+        # buzz lists frappe/payments in required_apps, so it must precede install-app.
+        bench get-app --skip-assets payments
+
+        if [ -n "$EXTRA_APP_URL" ]; then
+          bench get-app --skip-assets "$EXTRA_APP_URL"
+        fi
+
+        bench get-app --skip-assets buzz "$GITHUB_WORKSPACE"
+
+    - name: Install requirements
+      shell: bash -e {0}
+      working-directory: /home/runner/frappe-bench
+      env:
+        BUILD_ASSETS: ${{ inputs.build-assets }}
+      run: |
+        # `--dev` installs only python dev deps and `--node` only runs yarn, so
+        # they share nothing. App requirements came from `bench get-app`.
+        bench setup requirements --dev &
+        dev_pid=$!
+
+        if [ "$BUILD_ASSETS" == "true" ]; then
+          bench setup requirements --node
+        fi
+
+        wait "$dev_pid"
+
+    - name: Create site
+      shell: bash -e {0}
+      working-directory: /home/runner/frappe-bench
+      env:
+        BUILD_ASSETS: ${{ inputs.build-assets }}
+        EXTRA_APP_URL: ${{ inputs.extra-app-url }}
+        SITE: ${{ inputs.site-name }}
+      run: |
+        # The build is CPU-bound and the site is DB-bound; they share no state.
+        build_pid=""
+        if [ "$BUILD_ASSETS" == "true" ]; then
+          CI=Yes bench build &> "${RUNNER_TEMP}/build.log" &
+          build_pid=$!
+        fi
+
+        # The CI database is discarded at the end of the job, so crash safety buys
+        # nothing. `root` must match MARIADB_ROOT_PASSWORD on the caller's service.
+        mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "
+          SET GLOBAL innodb_flush_log_at_trx_commit = 0;
+          SET GLOBAL sync_binlog = 0;"
+
+        bench new-site --db-root-password root --admin-password admin "$SITE"
+
+        if [ -n "$EXTRA_APP_URL" ]; then
+          bench --site "$SITE" install-app "$(basename "$EXTRA_APP_URL" .git)"
+        fi
+
+        bench --site "$SITE" install-app buzz
+
+        bench --site "$SITE" set-config allow_tests true
+        bench --site "$SITE" set-config host_name "http://$SITE:8000"
+
+        if [ -n "$build_pid" ] && ! wait "$build_pid"; then
+          echo "Asset build failed:"
+          cat "${RUNNER_TEMP}/build.log"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,17 @@ on:
     branches:
       - develop
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   merge_group:
 
 concurrency:
-  group: ci-buzz-${{ github.event.number || github.sha }}
+  group: ci-buzz-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,6 +24,9 @@ jobs:
     strategy:
       fail-fast: false
     name: Server
+
+    env:
+      PYTHONWARNINGS: ignore
 
     services:
       redis-cache:
@@ -29,84 +38,33 @@ jobs:
         ports:
           - 11000:6379
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:11.8
         env:
-          MYSQL_ROOT_PASSWORD: root
+          MARIADB_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s --health-timeout=2s --health-retries=3
+          --tmpfs=/var/lib/mysql:rw,noexec,nosuid,size=2g
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Find tests
         run: |
           echo "Finding tests"
           grep -rn "def test" > /dev/null
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - name: Setup Bench
+        uses: ./.github/actions/setup-bench
         with:
-          python-version: '3.14'
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 24
-          check-latest: true
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install MariaDB Client
-        run: |
-          sudo apt update
-          sudo apt-get install mariadb-client
-
-      - name: Setup
-        run: |
-          pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
-          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
-          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
-
-      - name: Install
-        working-directory: /home/runner/frappe-bench
-        run: |
-          bench get-app buzz $GITHUB_WORKSPACE
-          bench get-app payments
-          bench get-app zoom_integration https://github.com/bwhtech/zoom_integration
-          bench setup requirements --dev
-          bench new-site --db-root-password root --admin-password admin test_site
-          bench --site test_site install-app zoom_integration
-          bench --site test_site install-app buzz
-          bench build
-        env:
-          CI: 'Yes'
+          # test_buzz_event imports zoom_integration.tests.zoom_fixtures.
+          extra-app-url: https://github.com/bwhtech/zoom_integration
 
       - name: Run Tests
         working-directory: /home/runner/frappe-bench
-        run: |
-          bench --site test_site set-config allow_tests true
-          bench --site test_site run-tests --app buzz
+        run: bench --site test_site run-tests --app buzz
         env:
           TYPE: server

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,7 +5,13 @@ on:
     branches:
       - develop
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   merge_group:
   workflow_dispatch:
 
@@ -16,8 +22,11 @@ concurrency:
 jobs:
   ui-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     name: Playwright E2E Tests
+
+    env:
+      PYTHONWARNINGS: ignore
 
     services:
       redis-cache:
@@ -29,113 +38,52 @@ jobs:
         ports:
           - 11000:6379
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:11.8
         env:
-          MYSQL_ROOT_PASSWORD: root
+          MARIADB_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s --health-timeout=2s --health-retries=3
+          --tmpfs=/var/lib/mysql:rw,noexec,nosuid,size=2g
 
     steps:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          check-latest: true
-
-      - name: Add to Hosts
-        run: echo "127.0.0.1 buzz.test" | sudo tee -a /etc/hosts
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
-
-      - name: Cache yarn
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install MariaDB Client
-        run: |
-          sudo apt update
-          sudo apt-get install mariadb-client
+          key: ${{ runner.os }}-playwright-${{ hashFiles('yarn.lock') }}
 
       - name: Setup Bench
-        run: |
-          pip install frappe-bench
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
-          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
-          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
-
-      - name: Install buzz
-        working-directory: /home/runner/frappe-bench
-        run: |
-          bench get-app payments
-          bench get-app buzz $GITHUB_WORKSPACE
-          bench setup requirements --dev
-          bench new-site --db-root-password root --admin-password admin buzz.test
-          bench --site buzz.test install-app buzz
-          bench build
-        env:
-          CI: "Yes"
-
-      - name: Configure Site for UI Tests
-        working-directory: /home/runner/frappe-bench
-        run: |
-          bench --site buzz.test set-config allow_tests true
-          bench --site buzz.test set-config host_name "http://buzz.test:8000"
+        uses: ./.github/actions/setup-bench
+        with:
+          site-name: buzz.test
+          build-assets: true
 
       - name: Create Test User
         working-directory: /home/runner/frappe-bench
-        run: bench --site buzz.test add-user testuser@buzz.test --first-name Test --last-name User --password Test@123 --add-role "System Manager"
+        run: >-
+          bench --site buzz.test add-user testuser@buzz.test
+          --first-name Test --last-name User --password Test@123
+          --add-role "System Manager"
 
       - name: Start Frappe Server
         working-directory: /home/runner/frappe-bench
         run: |
-          # Disable watch and schedule to reduce resource usage
-          sed -i 's/^watch:/# watch:/g' Procfile
-          sed -i 's/^schedule:/# schedule:/g' Procfile
-
-          # Start bench in background
           bench start &> bench_start.log &
-
-          # Wait for server to be ready
-          echo "Waiting for Frappe server to start..."
-          timeout 60 bash -c 'until curl -s http://buzz.test:8000 > /dev/null; do sleep 2; done'
-          echo "Frappe server is ready!"
+          timeout 60 bash -c \
+            'until curl -sf http://buzz.test:8000 > /dev/null; do sleep 1; done'
 
       - name: Install Playwright
         run: |
-          npm install
-          npx playwright install --with-deps chromium
+          # --ignore-scripts skips the postinstall that reinstalls the whole
+          # dashboard tree; the tests only need @playwright/test.
+          yarn install --frozen-lockfile --ignore-scripts
+          npx playwright install --with-deps --only-shell chromium
 
       - name: Run Playwright Tests
         run: npx playwright test


### PR DESCRIPTION
Playwright job usually ran ~5 min but spiked to ~15. The variance was one step: `Install Playwright`, 16s on a good run vs **624s** on a bad one (runs `30474649946` / `30473372443`). Tests themselves are stable at ~110s.

Cause: `gh cache list` shows the repo at GitHub's 10 GB cache cap with >8 GB of it yarn (`Linux-yarn-*` at 1.17 GB, 1.18 GB, 0.90 GB ×2, 0.77 GB). LRU eviction kills the 249 MB Playwright cache, so chromium re-downloads. The yarn caches grew forever because `restore-keys` restored the previous cache, `bench build` added to it, and the union got saved under a new key.

Fix: both test workflows now use setup-node's built-in yarn cache, no `restore-keys`, sharing one entry with typecheck/unit-tests. Playwright cache keys on `yarn.lock` instead of `hashFiles('**/package.json')` — `dashboard/package.json` changed 5× in the last 50 commits and was busting it for unrelated reasons.

Also extracts the provisioning both workflows duplicated into `.github/actions/setup-bench`, and overlaps what shares no state: apt with `uv tool install frappe-bench`, and `bench build` with `bench new-site`. Plus mariadb 10.6 → 11.8 with tmpfs and durability off, and `bench build` dropped from the server job.

Non-obvious bits a reviewer can't get from the diff:
- `bench build` runs root `package.json`'s `"build": "cd dashboard && yarn build"` via frappe's esbuild `--run-build-command`. It's a full vite build — that's why overlapping it with `new-site` is the win, not a micro-opt.
- **No `NODE_ENV: production`**, though frappe sets it. `vite`, `tailwindcss`, `@vitejs/plugin-vue` and `@playwright/test` are all devDependencies here; it would break the build and the tests.
- **socketio stays in the Procfile.** Frappe only strips it in *server* tests. `dashboard/src/main.ts:44` calls `initSocket()` on boot.
- Root install needs `--ignore-scripts` — the root `postinstall` is `cd dashboard && yarn install`.
- `bench setup requirements --dev` installs *only* python dev deps (`bench/commands/setup.py`, the `else` branch), so running it alongside `--node` is not a race.
- `bench get-app`'s NAME arg is `nargs=-1` and documented "Dummy argument for backward compatibility" — a bare URL is enough.

Not done: sharding Playwright (110s of tests vs ~100s provisioning per shard), `workers > 1` (projects share server state, `playwright.config.ts:20`), caching all of `~/frappe-bench` (1–2 GB into the budget that caused this).

Deferred: the oversized `Linux-yarn-*` cache entries still need `gh cache delete`. Pointless before this merges — develop's current workflows would recreate them on the next run.

**Checks:** actionlint clean, YAML parses, shellcheck clean on every `run` block, composite inputs cross-checked against both callers. Not run: the workflows themselves — they only execute on GitHub, so CI on this PR is the first real test. Expect the first run to be slow (cold caches); the second is the measurement.