### PR TITLE
fix(proposals): confirm before accepting a talk proposal

### DIFF
--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.js
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.js
@@ -11,18 +11,30 @@ frappe.ui.form.on("Talk Proposal", {
 
 	refresh(frm) {
 		if (frm.doc.status != "Accepted") {
-			const btn = frm.add_custom_button(__("Accept and Create Talk"), () => {
-				frm.call({
-					method: "create_talk",
-					doc: frm.doc,
-					btn,
-				}).then(({ message: talk }) => {
-					frm.set_value("status", "Accepted");
-					frm.save();
-					frm.refresh();
-					frappe.set_route("Form", "Event Talk", talk.name);
-				});
-			});
+			const btn = frm.add_custom_button(
+				__("Accept and Create Talk"),
+				() => {
+					frappe.confirm(
+						__(
+							"This action will accept this proposal and create a talk against it. Any speakers without a Buzz account will get one."
+						),
+						() => {
+							frm.call({
+								method: "create_talk",
+								doc: frm.doc,
+								btn,
+							}).then(({ message: talk }) => {
+								frappe.show_alert({
+									message: __("Talk created"),
+									indicator: "green",
+								});
+								frappe.set_route("Form", "Event Talk", talk.name);
+							});
+						}
+					);
+				},
+				__("Actions")
+			);
 		}
 	},
 });

--- a/buzz/proposals/doctype/talk_proposal/talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/talk_proposal.py
@@ -84,6 +84,7 @@ class TalkProposal(Document):
 							"first_name": speaker.first_name,
 							"last_name": speaker.last_name,
 							"email": speaker.email,
+							"user_type": "Website User",
 						}
 					)
 					.insert()
@@ -95,4 +96,8 @@ class TalkProposal(Document):
 				speaker_profile = frappe.get_doc({"doctype": "Speaker Profile", "user": user}).insert().name
 
 			talk.append("speakers", {"speaker": speaker_profile})
-		return talk.save()
+
+		talk.save()
+		self.status = "Accepted"
+		self.save()
+		return talk

--- a/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
+++ b/buzz/proposals/doctype/talk_proposal/test_talk_proposal.py
@@ -130,3 +130,39 @@ class TestTalkProposalSpeakerAccess(IntegrationTestCase):
 	def test_event_manager_sees_all_proposals(self):
 		frappe.set_user(self.manager_user)
 		self.assertIn(self.guest_proposal, frappe.get_list("Talk Proposal", pluck="name"))
+
+
+class TestCreateTalk(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.category = ensure_prompt_named_record("Event Category", "Proposal Perm Category")
+		cls.host = ensure_prompt_named_record("Event Host", "Proposal Perm Host")
+		cls.event = make_test_event(cls.category, cls.host)
+		cls.speaker_user = make_test_user("create-talk-speaker@example.com")
+
+	def test_create_talk_accepts_the_proposal(self):
+		proposal = frappe.get_doc("Talk Proposal", make_guest_proposal(self.event, self.speaker_user))
+
+		talk = proposal.create_talk()
+
+		self.assertEqual(talk.proposal, proposal.name)
+		self.assertEqual(frappe.db.get_value("Talk Proposal", proposal.name, "status"), "Accepted")
+
+	def test_speaker_without_an_account_gets_a_website_user(self):
+		email = f"new-speaker-{frappe.generate_hash(length=6)}@example.com"
+		proposal = frappe.get_doc("Talk Proposal", make_guest_proposal(self.event, email))
+
+		proposal.create_talk()
+
+		self.assertEqual(frappe.db.get_value("User", email, "user_type"), "Website User")
+
+	def test_second_create_talk_leaves_no_partial_state(self):
+		proposal = frappe.get_doc("Talk Proposal", make_guest_proposal(self.event, self.speaker_user))
+		proposal.create_talk()
+
+		proposal.reload()
+		with self.assertRaises(frappe.ValidationError):
+			proposal.create_talk()
+
+		self.assertEqual(frappe.db.count("Event Talk", {"proposal": proposal.name}), 1)


### PR DESCRIPTION
`Accept and Create Talk` sat in the primary button bar and fired on a single click. It is not a cheap action: it creates an Event Talk and, for every speaker without an account, a User and a Speaker Profile. One stray click made records that are annoying to unwind. Now it lives under `Actions` behind a confirmation.

While testing the confirm, an empty "Message" dialog showed up after clicking Yes. Two things were going on:

1. Creating a speaker User makes Frappe emit server messages ("Welcome email sent", "No Roles Specified").
2. The old handler did `frm.save()` without awaiting it, then `frm.refresh()`, then `set_route`. Two responses ended up in flight together. The second one calls `frappe.hide_msgprint()` while the first dialog is still fading, and `hidden.bs.modal` fires late — after the new message has been appended — so `onhide` empties the body of an already-visible dialog. Blank box, title "Message", blue dot.

So the status change moved into `create_talk` server-side and the handler is now just call → toast → route. No overlapping requests, no race. It also makes the two writes atomic: before, a failed `frm.save()` left the talk created but the proposal un-accepted, and the retry hit `Talk already created for this proposal!` with no way out.

Speaker Users are now created as Website Users, matching `get_or_create_guest_user` in the booking flow — they sign in to the dashboard, not the desk. This also stops the "No Roles Specified" msgprint, which only fires for System Users. The welcome email is unchanged and still sent.

Not changed: the `frappe.hide_msgprint` / `hidden.bs.modal` race is a Frappe core bug. Worth an upstream issue, not patched here.

Tests: 3 new ones covering the status flip, the Website User type, and that a second `create_talk` raises without leaving a second Event Talk behind. 10 pass in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)