### PR TITLE
ci: skip the expensive jobs on documentation-only changes

### DIFF
--- a/.github/actions/detect-code-changes/action.yml
+++ b/.github/actions/detect-code-changes/action.yml
@@ -1,0 +1,56 @@
+name: "Detect Code Changes"
+description: "Reports whether the event touched anything a build or test could care about"
+
+outputs:
+  code:
+    description: "'true' unless this is a pull request that only touched documentation"
+    value: ${{ steps.detect.outputs.code }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect
+      id: detect
+      shell: bash -e {0}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        # Only a pull request has a base to diff against. push, merge_group,
+        # workflow_dispatch and schedule all guard a branch directly, so they run
+        # everything.
+        if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+          echo "Event is $GITHUB_EVENT_NAME, nothing to diff." >> "$GITHUB_STEP_SUMMARY"
+          echo "code=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Fails open: downstream jobs are skipped when this one fails, and a
+        # skipped required check counts as successful, so an API hiccup must
+        # never look like "documentation only".
+        files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+          --jq '.[].filename') || files=""
+
+        if [ -z "$files" ]; then
+          echo "No file list available, running everything." >> "$GITHUB_STEP_SUMMARY"
+          echo "code=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        code=false
+        while IFS= read -r file; do
+          case "$file" in
+            *.md | docs/* | .claude/* | specs/*) ;;
+            *)
+              echo "Code change: $file" >> "$GITHUB_STEP_SUMMARY"
+              code=true
+              break
+              ;;
+          esac
+        done <<< "$files"
+
+        if [ "$code" = false ]; then
+          echo "Documentation only." >> "$GITHUB_STEP_SUMMARY"
+        fi
+        echo "code=$code" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,7 @@ on:
     branches:
       - develop
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   merge_group:
 
 concurrency:
@@ -19,7 +13,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,8 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   typecheck:
     name: TypeScript
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,13 +5,7 @@ on:
     branches:
       - develop
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   merge_group:
   workflow_dispatch:
 
@@ -20,7 +14,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   ui-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Playwright E2E Tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,8 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        uses: ./.github/actions/detect-code-changes
+
   unit-tests:
     name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
`ci.yml` and `ui-tests.yml` carried `paths-ignore` for `**.md` and `docs/**`. That
was worse than it looks. A workflow skipped by path filtering never reports its
checks — they stay Pending. `Server` and `Playwright E2E Tests` are required
checks in the `protect-develop` ruleset, so a docs-only PR wasn't just skipping
CI, it could never be merged. A job skipped by a job-level `if:` reports Success
and satisfies a required check. Hence the shape of this change: the filter moves
off the trigger and onto the jobs.

A `changes` job on `ubuntu-slim` computes one boolean; the expensive job takes
`needs: changes` and an `if:` on it. The detection is a composite action in
`.github/actions/` so four workflows share one copy. It reads the PR's file list
with `gh api` instead of `git diff`, which avoids deepening the clone. Docs paths
are `**.md`, `docs/**`, `.claude/**`, `specs/**`.

Only `pull_request` has a base to diff against, so every other event falls
through to running everything. The `gh api` call also fails open — a skipped
required check reads as Success, so a transient API failure must not look like
"docs only".

Per event, for all four gated workflows:

| Event | Gate | Expensive job |
|---|---|---|
| docs-only PR | `code=false` | skipped → check reports Success, PR is mergeable |
| mixed docs+code PR | `code=true` | runs (first non-doc file wins) |
| code-only PR | `code=true` | runs |
| `merge_group` | not a PR → `code=true` | runs |
| `push` to `develop`/`main` | not a PR → `code=true` | runs |
| `workflow_dispatch` (ui-tests) | not a PR → `code=true` | runs |

Deliberately unchanged:

- **`linter.yml` is not gated.** `Frappe Linter` is the cheapest of the
  expensive jobs, and it's the only one that validates the non-`.md` doc paths —
  `check-json`, `check-yaml` and `check-ast` in `.pre-commit-config.yaml` are
  unscoped, so gating it would stop catching a malformed `.claude/settings.json`
  on exactly the PRs that touch it. Its `schedule` trigger, `workflow_dispatch`,
  the `if: github.event_name != 'schedule'` condition and the separate
  `Vulnerable Dependency Check` job are all untouched.
- No job or workflow `name:` was renamed — the five required contexts are matched
  as strings.
- `concurrency` groups and existing permissions are as they were. The `changes`
  jobs declare their own `contents: read` / `pull-requests: read`.
- `pr-tittle-check.yml` and `backport.yml` are cheap or event-specific.

Verified: `actionlint` reports nothing new (its one SC2086 hit is pre-existing in
the untouched `linter.yml` and identical on `develop`). The `run:` script was
extracted from `action.yml` and executed against a stubbed `gh` for all nine
cases — docs-only, mixed, code-only, `.github/**`, the four non-PR events, and a
failing `gh` — each giving the expected `code=`. On this PR the gate correctly
read `.github/**` as code and every job ran.

Not verified: a real docs-only PR end to end, and the `merge_group` path, neither
of which can be exercised before this merges. Both are covered by the harness
only.
