### PR TITLE
feat(events): autofill and bound End Date from Start Date

### DIFF
--- a/buzz/events/doctype/buzz_event/buzz_event.js
+++ b/buzz/events/doctype/buzz_event/buzz_event.js
@@ -304,9 +304,18 @@ frappe.ui.form.on("Buzz Event Form", {
 	},
 });
 
+// min_date on the df is only read when the control builds its picker,
+// so the datepicker instance has to be updated directly.
+function set_end_date_limit(frm) {
+	frm.fields_dict.end_date.datepicker?.update({
+		minDate: frm.doc.start_date ? frappe.datetime.str_to_obj(frm.doc.start_date) : null,
+	});
+}
+
 frappe.ui.form.on("Buzz Event", {
 	refresh(frm) {
 		frm.fields_dict.time_zone.set_data(getZoomSupportedTimezones());
+		set_end_date_limit(frm);
 
 		if (frm.doc.route && frm.doc.is_published) {
 			frm.add_web_link(`/events/${frm.doc.route}`);
@@ -387,6 +396,15 @@ frappe.ui.form.on("Buzz Event", {
 				frm.layout.tabs.find((t) => t.label == "Zoom Integration").set_active();
 			});
 		});
+	},
+	start_date(frm) {
+		if (frm.doc.start_date && !frm.doc.end_date) {
+			frm.set_value("end_date", frm.doc.start_date);
+		} else if (frm.doc.start_date && frm.doc.end_date < frm.doc.start_date) {
+			frm.set_value("end_date", frm.doc.start_date);
+			frappe.show_alert(__("End Date moved to match Start Date"));
+		}
+		set_end_date_limit(frm);
 	},
 	category(frm) {
 		if (!frm.is_new()) return;


### PR DESCRIPTION
Picking a Start Date on Buzz Event left End Date entirely on the user, and nothing stopped them from putting it before the start. The server caught that on save via `validate_from_to_dates`, but only after a full round trip.

Three small things in `buzz_event.js`:

- Start Date fills an empty End Date with the same value. Non-empty End Date is left alone.
- If the new Start Date is past the existing End Date, End Date is pulled forward to match and an alert says so. Silently saving an invalid range was the alternative.
- The End Date picker gets a `minDate`, so earlier dates aren't offered in the first place.

Gotchas worth knowing:

`min_date` on the docfield is only read once, when the control builds its picker — `set_df_property` does nothing after that. The limit has to go onto the datepicker instance directly (`field.datepicker.update({ minDate })`), same as `frappe/form/reminders.js` does. Hence the `set_end_date_limit` helper, called from both `refresh` and `start_date`.

`minDate` is inclusive, so end == start is still allowed. It has to be — single-day events are the common case and the autofill produces exactly that.

Dates are `YYYY-MM-DD` strings, so the `<` comparison is chronological. No date lib needed.

Not changed:

- No new server-side validation. `validate_dates` already calls `validate_from_to_dates("start_date", "end_date")`; this is a UX layer on top, not a replacement.
- `validate_schedule` untouched. Pulling End Date forward can now strand schedule rows past it — the server already throws on those, which is the right place for it.

Desk-only change, no dashboard impact.