### PR TITLE
fix(teams): show only the user's own teams in the Buzz Team picker

### DIFF
--- a/buzz/events/doctype/buzz_team/buzz_team.py
+++ b/buzz/events/doctype/buzz_team/buzz_team.py
@@ -8,7 +8,7 @@ from frappe.model.naming import append_number_if_name_exists
 
 from buzz.events.doctype.buzz_team_membership.buzz_team_membership import upsert_membership
 from buzz.events.doctype.buzz_team_settings.buzz_team_settings import create_team_settings
-from buzz.permissions import can_manage_members
+from buzz.permissions import can_manage_members, my_team_names
 
 SEARCH_LIMIT = 10
 STANDARD_USERS = ("Administrator", "Guest")
@@ -38,11 +38,7 @@ def set_team_from_sole_membership(doc, event=None):
 	if doc.team:
 		return
 
-	teams = frappe.get_all(
-		"Buzz Team Membership",
-		filters={"user": frappe.session.user, "enabled": 1},
-		pluck="team",
-	)
+	teams = my_team_names(frappe.session.user)
 	if len(teams) == 1:
 		doc.team = teams[0]
 

--- a/buzz/hooks.py
+++ b/buzz/hooks.py
@@ -222,6 +222,10 @@ permission_query_conditions = {
 	"Talk Proposal": "buzz.proposals.doctype.talk_proposal.talk_proposal.get_permission_query_conditions",
 }
 
+# Every Buzz Team link field, not one form at a time: the permission hooks let a System
+# Manager read all teams, which is right for support and wrong for a picker.
+standard_queries = {"Buzz Team": "buzz.permissions.team_link_query"}
+
 has_permission = {
 	"Buzz Event": "buzz.permissions.team_has_permission",
 	"Buzz Campaign": "buzz.permissions.team_has_permission",

--- a/buzz/permissions.py
+++ b/buzz/permissions.py
@@ -26,6 +26,33 @@ def my_teams(user: str) -> QueryBuilder:
 	)
 
 
+def my_team_names(user: str) -> list[str]:
+	return frappe.get_all("Buzz Team Membership", filters={"user": user, "enabled": 1}, pluck="team")
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def team_link_query(
+	doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict | None
+) -> list[tuple]:
+	"""Link fields offer the user's own teams only.
+
+	Narrower than the read permission on purpose: a System Manager reads every team for
+	support, but stamping a document with a team they are not on is never intended.
+	"""
+	pattern = f"%{txt}%"
+	return frappe.get_all(
+		"Buzz Team",
+		filters={**(filters or {}), "name": ("in", my_team_names(frappe.session.user))},
+		or_filters=[["name", "like", pattern], ["team_name", "like", pattern]],
+		fields=["name", "team_name"],
+		order_by="team_name asc",
+		limit_start=start,
+		limit_page_length=page_len,
+		as_list=True,
+	)
+
+
 def published_events() -> QueryBuilder:
 	event = frappe.qb.DocType("Buzz Event")
 	return frappe.qb.from_(event).select(event.name).where(event.is_published == 1)

--- a/buzz/test_permissions.py
+++ b/buzz/test_permissions.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.desk.search import search_link
 from frappe.tests import IntegrationTestCase
 
 from buzz.api.checkin.exceptions import TicketNotFound
@@ -232,6 +233,36 @@ class TestMultiTeamMembership(TeamPermissionTestCase):
 
 		self.assertIn(self.event_a, events)
 		self.assertNotIn(self.event_b, events)
+
+
+class TestTeamLinkQuery(TeamPermissionTestCase):
+	def searched(self, txt: str = "") -> list[str]:
+		results = search_link("Buzz Team", txt, reference_doctype="Buzz Event")
+		return [result["value"] for result in results]
+
+	def test_link_search_offers_only_the_users_teams(self):
+		self.as_user(self.alice)
+		teams = self.searched()
+
+		self.assertIn(self.team_a, teams)
+		self.assertNotIn(self.team_b, teams)
+
+	def test_link_search_matches_the_team_name(self):
+		self.as_user(self.alice)
+
+		self.assertEqual(self.searched("Perm Team A"), [self.team_a])
+		self.assertEqual(self.searched("Perm Team B"), [])
+
+	def test_system_manager_is_narrowed_here_despite_reading_every_team(self):
+		# Administrator is on neither team, but the permission hooks let it list both.
+		self.assertIn(self.team_b, frappe.get_list("Buzz Team", pluck="name"))
+
+		self.assertNotIn(self.team_b, self.searched())
+
+	def test_non_member_gets_nothing(self):
+		self.as_user(self.outsider)
+
+		self.assertEqual(self.searched(), [])
 
 
 class TestRoleMatrix(TeamPermissionTestCase):


### PR DESCRIPTION
The `team` Link on Buzz Event offered every team on the site to anyone holding System Manager — which is most desk accounts on a real install. Reported from the New Buzz Event form.

Not a permission bug: `is_unrestricted` returns no query condition for Administrator/System Manager on purpose, so support can read across teams. But a picker is not a list view, and a team you are not a member of is never the right value to stamp a document with.

## Approach

`standard_queries = {"Buzz Team": "buzz.permissions.team_link_query"}`, rather than narrowing `is_unrestricted`.

- Support keeps its cross-team reads; only the picker narrows.
- One hook covers every Buzz Team link field — Buzz Event, Event Venue, Event Host, Event Template, Buzz Campaign — instead of a `set_query` in five Desk scripts.
- `team_link_query` filters on membership directly, so it uses `frappe.get_all`; the permission query condition it would otherwise pass through is the no-op that caused this.
- `set_team_from_sole_membership` now shares the membership lookup as `my_team_names`.

## Not changed

Advanced Search, `frappe.client`, REST and the dashboard still reach every team the permission hooks allow. If that turns out to matter it is a separate call, and it is the one that would break support.

## Verified

On a local site, after `clear-cache`:

```
harsh@example.com (System Manager, member of BTEAM0001) → [BTEAM0001]
Administrator     (member of BTEAM0002)                 → [BTEAM0002]
```

Four new tests in `TestTeamLinkQuery` cover own-team-only, name matching, the System Manager case, and a non-member getting nothing. Full app suite: 468 tests, OK (2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
