### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to Buzz are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release lines
+
+- **`main` — 1.x (stable).** The supported release line. Fixes and self-contained
+  features are merged to `develop` first and cherry-picked here with a
+  `backport main` label.
+- **`develop` — 2.x (beta).** Where the next major lands, including team-based
+  multi-tenancy. Not yet released.
+
+## [1.1.0] - 2026-08-06
+
+### Breaking
+
+- The dashboard has been migrated to **frappe-ui v1 and Vite 8** ([#283]). The
+  dashboard build and any downstream customisation of dashboard components are
+  affected — component imports, prop names and build output paths changed with the
+  frappe-ui major. Rebuild the dashboard (`yarn build`) after upgrading. There is
+  no change to the Python API surface or to any DocType schema, so no data
+  migration is required for this release.
+
+### Added
+
+- Buzz Events can be backed by **Zoom Meetings**, creating the meeting and
+  registering attendees through the optional `zoom_integration` app ([#292]).
+- A **Buzz workspace dashboard** with charts and number cards ([#314]).
+- Speakers can now see and edit their own talk proposals ([#276]).
+- Buzz Event stores a short timezone label for display ([#282]).
+- Event End Date is autofilled from Start Date and bounded by it ([#316]).
+
+### Changed
+
+- `buzz/api` is split into typed domain packages, with pydantic request/response
+  schemas, service classes and enforced type annotations on whitelisted
+  methods ([#307]).
+- The phone field uses the `PhoneInput` component instead of a plain
+  `FormControl` ([#290]).
+- README hero revamped with logo and badges ([#285]).
+
+### Fixed
+
+- Accepting a talk proposal now asks for confirmation first ([#309]).
+- "To" is prefilled when composing email on proposal doctypes ([#294]).
+- Resolved semgrep blocking findings reported by the full-repo scan ([#281]).
+
+### CI
+
+- Fixed merge-queue trigger gaps; CI now runs on both `develop` and `main` ([#279]).
+
+## [1.0.0] - 2026-07-21
+
+Initial tagged release.
+
+[#276]: https://github.com/bwhtech/buzz/pull/276
+[#279]: https://github.com/bwhtech/buzz/pull/279
+[#281]: https://github.com/bwhtech/buzz/pull/281
+[#282]: https://github.com/bwhtech/buzz/pull/282
+[#283]: https://github.com/bwhtech/buzz/pull/283
+[#285]: https://github.com/bwhtech/buzz/pull/285
+[#290]: https://github.com/bwhtech/buzz/pull/290
+[#292]: https://github.com/bwhtech/buzz/pull/292
+[#294]: https://github.com/bwhtech/buzz/pull/294
+[#307]: https://github.com/bwhtech/buzz/pull/307
+[#309]: https://github.com/bwhtech/buzz/pull/309
+[#314]: https://github.com/bwhtech/buzz/pull/314
+[#316]: https://github.com/bwhtech/buzz/pull/316
+[1.1.0]: https://github.com/bwhtech/buzz/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/bwhtech/buzz/releases/tag/v1.0.0

--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Cuts the **1.1.0** release from `main`, covering everything backported since `v1.0.0`.

This also writes down the branch policy we're adopting: **`main` carries the 1.x stable line, `develop` carries the 2.x beta line.** Team-based multi-tenancy (#312 / #317) is v2 material and stays on `develop`.

## Changes

- `buzz/__init__.py`: `__version__` → `1.1.0` (the version of record; `pyproject.toml` reads it dynamically)
- `package.json`: `version` → `1.1.0` for consistency — note the 1.0.0 release only touched `buzz/__init__.py`, so drop this hunk if you'd rather keep the bump to a single file
- New `CHANGELOG.md`, seeded with this release and a `1.0.0` baseline entry

`dashboard/package.json` is left at `0.0.0` — it has never been bumped and isn't published.

## Release contents

13 commits on `main` since `v1.0.0`:

**Breaking** — the dashboard was migrated to frappe-ui v1 and Vite 8 (#283). Component imports, prop names and build output changed with the frappe-ui major, so the dashboard needs a rebuild and downstream customisations are affected. No Python API or DocType schema change, so no data migration.

**Added** — Zoom-backed events (#292), Buzz workspace dashboard (#314), speaker-editable talk proposals (#276), short timezone label on Buzz Event (#282), End Date autofill (#316)

**Changed** — `buzz/api` split into typed domain packages (#307), `PhoneInput` for phone fields (#290), README hero (#285)

**Fixed** — confirm before accepting a proposal (#309), prefill "To" on proposal emails (#294), semgrep full-repo findings (#281)

**CI** — merge-queue trigger gaps (#279)

## Versioning note

#283 is a `feat!`, which strict semver would make a 2.0.0. It's shipping as a minor deliberately: the break is dashboard-internal, and 2.0.0 is reserved for the v2 line on `develop`. The breaking change is called out prominently in the changelog instead.

## Do not backport this one

Unlike the 1.0.0 bump (#270 → #271), this must **not** get a `backport develop` label — `develop` should carry a `2.0.0-beta` version, not `1.1.0`. Happy to open that bump as a separate PR against `develop`.

## After merge

Tag `v1.1.0` on the merge commit **on `main`** and publish the release. Worth noting the `v1.0.0` tag points at `13a1a29`, the develop-side backport commit rather than `main`'s `85fa5f6` — tagging this one on `main` keeps the line consistent going forward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqhZUMguWUR63DcCdUBP9W)_