### PR TITLE
chore: open the 2.0.0-beta line on develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ Pre-commit is configured to use the following tools for checking and formatting 
 - eslint
 - prettier
 - pyupgrade
+
+#### Branches
+
+Buzz is developed on two release lines:
+
+| Branch | Line | What it is |
+| --- | --- | --- |
+| `main` | 1.x — stable | The supported release line, and what `bench get-app` installs by default. |
+| `develop` | 2.x — beta | Where the next major lands, including team-based multi-tenancy. Not yet released. |
+
+Open your pull request against `develop`. Once it is merged, add a `backport main`
+label to cherry-pick it onto the stable line — the [backport
+workflow](.github/workflows/backport.yml) opens the follow-up PR for you. Changes
+that target 2.x only, such as anything building on teams, stay on `develop` and
+should not be labelled.
+
 ### CI
 
 This app can use GitHub Actions for CI. The following workflows are configured:

--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "2.0.0b0"
 
 import os
 

--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0b0"
+__version__ = "2.0.0-beta.0"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Companion to #320. That PR cuts **1.1.0** on `main`; this one opens the **2.x beta** line here so `develop` doesn't inherit a 1.x version.

Split of the two lines: **`main` = 1.x stable, `develop` = 2.x beta.**

## Changes

- `buzz/__init__.py`: `__version__` → `2.0.0b0`
- `package.json`: `version` → `2.0.0-beta.0`
- `README.md`: a short **Branches** subsection under Contributing

### Why the two version strings differ

They're the same version in each ecosystem's canonical pre-release form:

- `2.0.0b0` is the PEP 440 normalised form. flit reads `__version__` as the package version (`dynamic = ["version"]` in `pyproject.toml`), and writing `2.0.0-beta.0` there would rely on flit normalising it — some flit versions error on a non-normalised version instead. `2.0.0b0` avoids the question.
- `2.0.0-beta.0` is the semver form npm expects; `2.0.0b0` is not valid semver.

Worth a sanity check on your side: I couldn't run flit here (`flit_core` isn't installed in this environment), so the PEP 440 reasoning is from `packaging`, which normalises `2.0.0-beta.0` → `2.0.0b0`. A `bench build` / editable install on a real bench would confirm it.

### README

The new subsection sits directly above the CI section and states which branch to target, that a merged PR gets a `backport main` label to reach the stable line, and that 2.x-only work stays here unlabelled. It goes next to the existing contributing instructions because that's where someone deciding their base branch is already looking.

Note the install instructions further up already say `bench get-app --branch main`, which stays correct under this split.

## Sequencing

Independent of #320 — no shared files land on both branches, so either can merge first. And like #320, this one must **not** get a `backport main` label.