### PR TITLE
fix: let guests switch language, and honour ?lang=

### DIFF
--- a/buzz/api/account/__init__.py
+++ b/buzz/api/account/__init__.py
@@ -3,6 +3,7 @@ from frappe.translate import get_all_translations
 
 from buzz.api.account.exceptions import UnknownLanguage
 from buzz.api.account.schemas import GuestInfoResponse, LanguageOption, UserInfoResponse
+from buzz.api.account.services import get_request_language
 
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
@@ -11,6 +12,7 @@ def get_user_info() -> UserInfoResponse | GuestInfoResponse:
 		return GuestInfoResponse(
 			is_logged_in=False,
 			brand_image=frappe.get_cached_value("Website Settings", "Website Settings", "banner_image"),
+			language=get_request_language(),
 		)
 
 	user = frappe.get_cached_doc("User", frappe.session.user)
@@ -40,7 +42,10 @@ def get_enabled_languages() -> list[LanguageOption]:
 	return [LanguageOption(**language) for language in languages]
 
 
-@frappe.whitelist()
+# Deliberately not guest-whitelisted: every guest shares the one `Guest` User,
+# so a write here would set the language for every other visitor. Guests switch
+# language through the `preferred_language` cookie instead.
+@frappe.whitelist(methods=["POST"])
 def update_user_language(language_code: str) -> None:
 	if not frappe.db.exists("Language", {"language_code": language_code}):
 		UnknownLanguage.throw(language_code=language_code)
@@ -50,12 +55,7 @@ def update_user_language(language_code: str) -> None:
 
 @frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_translations() -> dict:
-	if frappe.session.user != "Guest":
-		language = frappe.db.get_value("User", frappe.session.user, "language")
-	else:
-		language = frappe.db.get_single_value("System Settings", "language")
-
-	return get_all_translations(language)
+	return get_all_translations(get_request_language())
 
 
 def has_app_permission() -> bool:

--- a/buzz/api/account/__init__.py
+++ b/buzz/api/account/__init__.py
@@ -42,9 +42,9 @@ def get_enabled_languages() -> list[LanguageOption]:
 	return [LanguageOption(**language) for language in languages]
 
 
-# Deliberately not guest-whitelisted: every guest shares the one `Guest` User,
-# so a write here would set the language for every other visitor. Guests switch
-# language through the `preferred_language` cookie instead.
+# Deliberately not guest-whitelisted: every guest shares the one `Guest` User, so
+# a write here would set the language for every visitor. Guests use the
+# `preferred_language` cookie instead.
 @frappe.whitelist(methods=["POST"])
 def update_user_language(language_code: str) -> None:
 	if not frappe.db.exists("Language", {"language_code": language_code}):

--- a/buzz/api/account/schemas.py
+++ b/buzz/api/account/schemas.py
@@ -4,6 +4,9 @@ from buzz.api.schemas import APIResponse
 class GuestInfoResponse(APIResponse):
 	is_logged_in: bool
 	brand_image: str | None
+	# Resolved per browser from the `preferred_language` cookie, so the language
+	# switcher can show a guest the language actually in effect.
+	language: str
 
 
 class UserInfoResponse(APIResponse):

--- a/buzz/api/account/schemas.py
+++ b/buzz/api/account/schemas.py
@@ -4,8 +4,7 @@ from buzz.api.schemas import APIResponse
 class GuestInfoResponse(APIResponse):
 	is_logged_in: bool
 	brand_image: str | None
-	# Resolved per browser from the `preferred_language` cookie, so the language
-	# switcher can show a guest the language actually in effect.
+	# Resolved per browser, so the switcher can show a guest the language in effect.
 	language: str
 
 

--- a/buzz/api/account/services.py
+++ b/buzz/api/account/services.py
@@ -1,0 +1,26 @@
+import frappe
+from frappe.translate import get_language
+
+
+def get_request_language() -> str:
+	"""Language the current request should be served in.
+
+	Logged-in users resolve from their own User document. Guests all share the
+	one `Guest` User, so there is nothing per-visitor to read there — frappe's
+	`get_language` picks the `preferred_language` cookie, then the
+	`Accept-Language` header, then the System Settings default.
+	"""
+	if frappe.session.user != "Guest":
+		return frappe.db.get_value("User", frappe.session.user, "language") or get_default_language()
+
+	# get_language reads cookies and headers straight off the live request;
+	# background jobs and the console have none.
+	if not frappe.request:
+		return get_default_language()
+
+	return get_language()
+
+
+def get_default_language() -> str:
+	"""Site-wide language from System Settings, falling back to English."""
+	return frappe.get_system_settings("language") or "en"

--- a/buzz/api/account/services.py
+++ b/buzz/api/account/services.py
@@ -5,16 +5,14 @@ from frappe.translate import get_language
 def get_request_language() -> str:
 	"""Language the current request should be served in.
 
-	Logged-in users resolve from their own User document. Guests all share the
-	one `Guest` User, so there is nothing per-visitor to read there — frappe's
-	`get_language` picks the `preferred_language` cookie, then the
-	`Accept-Language` header, then the System Settings default.
+	A logged-in user's own User document, else `get_language`'s order:
+	`preferred_language` cookie, `Accept-Language` header, System Settings.
 	"""
 	if frappe.session.user != "Guest":
 		return frappe.db.get_value("User", frappe.session.user, "language") or get_default_language()
 
-	# get_language reads cookies and headers straight off the live request;
-	# background jobs and the console have none.
+	# get_language reads cookies and headers off the live request; background
+	# jobs and the console have none.
 	if not frappe.request:
 		return get_default_language()
 
@@ -22,5 +20,4 @@ def get_request_language() -> str:
 
 
 def get_default_language() -> str:
-	"""Site-wide language from System Settings, falling back to English."""
 	return frappe.get_system_settings("language") or "en"

--- a/buzz/api/account/test_account.py
+++ b/buzz/api/account/test_account.py
@@ -38,12 +38,16 @@ class LanguageTestCase(IntegrationTestCase):
 		return frappe.get_system_settings("language") or "en"
 
 	def other_enabled_language(self) -> str:
-		"""An enabled language that is not the site default."""
+		"""An enabled language that is not the site default.
+
+		Plain codes only: a regional one like `pt-BR` is a different string once
+		it has been through werkzeug's Accept-Language parsing.
+		"""
 		for language in get_all_languages():
-			if language != self.default_language():
+			if language != self.default_language() and language.isalpha():
 				return language
 
-		self.skipTest("site has only one enabled language")
+		self.skipTest("site has no second enabled language with a plain code")
 
 	def set_user_language(self, language: str | None):
 		original = frappe.db.get_value("User", "Administrator", "language")

--- a/buzz/api/account/test_account.py
+++ b/buzz/api/account/test_account.py
@@ -12,13 +12,14 @@ from buzz.api.account import (
 	update_user_language,
 )
 from buzz.api.account.exceptions import UnknownLanguage
+from buzz.api.account.services import get_default_language
 
 
 class LanguageTestCase(IntegrationTestCase):
 	"""Base for the tests that exercise language resolution.
 
-	`frappe.translate.get_language` reads cookies and headers off the live
-	request, which a test process does not have until one is installed.
+	`get_language` reads cookies and headers off the live request, which a test
+	process does not have until one is installed.
 	"""
 
 	def tearDown(self):
@@ -34,17 +35,14 @@ class LanguageTestCase(IntegrationTestCase):
 		set_request(method="GET", path="/api/method/get_translations", headers=headers)
 		self.addCleanup(setattr, frappe.local, "request", None)
 
-	def default_language(self) -> str:
-		return frappe.get_system_settings("language") or "en"
-
 	def other_enabled_language(self) -> str:
 		"""An enabled language that is not the site default.
 
-		Plain codes only: a regional one like `pt-BR` is a different string once
-		it has been through werkzeug's Accept-Language parsing.
+		Plain codes only: a regional one like `pt-BR` comes back as a different
+		string once werkzeug has parsed the Accept-Language header.
 		"""
 		for language in get_all_languages():
-			if language != self.default_language() and language.isalpha():
+			if language != get_default_language() and language.isalpha():
 				return language
 
 		self.skipTest("site has no second enabled language with a plain code")
@@ -69,14 +67,13 @@ class TestGetUserInfo(LanguageTestCase):
 		self.install_request(cookies={"preferred_language": language})
 		frappe.set_user("Guest")
 
-		# Without this the switcher label is stuck on "en" whatever the guest picks.
 		self.assertEqual(get_user_info().__json__()["language"], language)
 
 	def test_guest_language_falls_back_to_the_site_default(self):
 		self.install_request()
 		frappe.set_user("Guest")
 
-		self.assertEqual(get_user_info().__json__()["language"], self.default_language())
+		self.assertEqual(get_user_info().__json__()["language"], get_default_language())
 
 	def test_logged_in_payload_shape(self):
 		info = get_user_info().__json__()
@@ -134,8 +131,7 @@ class TestLanguages(LanguageTestCase):
 		self.assertEqual(frappe.db.get_value("User", "Administrator", "language"), "en")
 
 	def test_update_stays_closed_to_guests(self):
-		# Every guest shares the one `Guest` User, so a guest write here would
-		# change the language for every other visitor.
+		self.assertIn(update_user_language, frappe.whitelisted)
 		self.assertNotIn(update_user_language, frappe.guest_methods)
 
 
@@ -166,7 +162,7 @@ class TestGetTranslations(LanguageTestCase):
 		self.install_request()
 		frappe.set_user("Guest")
 
-		self.assertEqual(self.resolved_language(), self.default_language())
+		self.assertEqual(self.resolved_language(), get_default_language())
 
 	def test_logged_in_translations_follow_the_user_document(self):
 		language = self.other_enabled_language()
@@ -177,4 +173,4 @@ class TestGetTranslations(LanguageTestCase):
 	def test_a_user_without_a_language_gets_the_site_default(self):
 		self.set_user_language(None)
 
-		self.assertEqual(self.resolved_language(), self.default_language())
+		self.assertEqual(self.resolved_language(), get_default_language())

--- a/buzz/api/account/test_account.py
+++ b/buzz/api/account/test_account.py
@@ -1,20 +1,78 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.translate import get_all_languages
+from frappe.utils import set_request
 
-from buzz.api.account import get_enabled_languages, get_user_info, update_user_language
+from buzz.api.account import (
+	get_enabled_languages,
+	get_translations,
+	get_user_info,
+	update_user_language,
+)
 from buzz.api.account.exceptions import UnknownLanguage
 
 
-class TestGetUserInfo(IntegrationTestCase):
+class LanguageTestCase(IntegrationTestCase):
+	"""Base for the tests that exercise language resolution.
+
+	`frappe.translate.get_language` reads cookies and headers off the live
+	request, which a test process does not have until one is installed.
+	"""
+
 	def tearDown(self):
 		frappe.set_user("Administrator")
 
-	def test_guest_payload_carries_only_two_keys(self):
+	def install_request(self, cookies: dict[str, str] | None = None, accept_language: str = ""):
+		headers = {}
+		if cookies:
+			headers["Cookie"] = "; ".join(f"{key}={value}" for key, value in cookies.items())
+		if accept_language:
+			headers["Accept-Language"] = accept_language
+
+		set_request(method="GET", path="/api/method/get_translations", headers=headers)
+		self.addCleanup(setattr, frappe.local, "request", None)
+
+	def default_language(self) -> str:
+		return frappe.get_system_settings("language") or "en"
+
+	def other_enabled_language(self) -> str:
+		"""An enabled language that is not the site default."""
+		for language in get_all_languages():
+			if language != self.default_language():
+				return language
+
+		self.skipTest("site has only one enabled language")
+
+	def set_user_language(self, language: str | None):
+		original = frappe.db.get_value("User", "Administrator", "language")
+		self.addCleanup(frappe.db.set_value, "User", "Administrator", "language", original)
+		frappe.db.set_value("User", "Administrator", "language", language)
+
+
+class TestGetUserInfo(LanguageTestCase):
+	def test_guest_payload_keys(self):
+		self.install_request()
 		frappe.set_user("Guest")
 		info = get_user_info().__json__()
 
-		self.assertEqual(set(info), {"is_logged_in", "brand_image"})
+		self.assertEqual(set(info), {"is_logged_in", "brand_image", "language"})
 		self.assertFalse(info["is_logged_in"])
+
+	def test_guest_language_follows_the_preferred_language_cookie(self):
+		language = self.other_enabled_language()
+		self.install_request(cookies={"preferred_language": language})
+		frappe.set_user("Guest")
+
+		# Without this the switcher label is stuck on "en" whatever the guest picks.
+		self.assertEqual(get_user_info().__json__()["language"], language)
+
+	def test_guest_language_falls_back_to_the_site_default(self):
+		self.install_request()
+		frappe.set_user("Guest")
+
+		self.assertEqual(get_user_info().__json__()["language"], self.default_language())
 
 	def test_logged_in_payload_shape(self):
 		info = get_user_info().__json__()
@@ -44,10 +102,7 @@ class TestGetUserInfo(IntegrationTestCase):
 		self.assertTrue(any(row.role == "Administrator" for row in roles))
 
 
-class TestLanguages(IntegrationTestCase):
-	def tearDown(self):
-		frappe.set_user("Administrator")
-
+class TestLanguages(LanguageTestCase):
 	def test_enabled_languages_shape(self):
 		languages = [language.__json__() for language in get_enabled_languages()]
 
@@ -68,9 +123,54 @@ class TestLanguages(IntegrationTestCase):
 		self.assertEqual(UnknownLanguage.http_status_code, 400)
 
 	def test_update_persists_language(self):
-		original = frappe.db.get_value("User", "Administrator", "language")
-		self.addCleanup(frappe.db.set_value, "User", "Administrator", "language", original)
+		self.set_user_language(None)
 
 		update_user_language("en")
 
 		self.assertEqual(frappe.db.get_value("User", "Administrator", "language"), "en")
+
+	def test_update_stays_closed_to_guests(self):
+		# Every guest shares the one `Guest` User, so a guest write here would
+		# change the language for every other visitor.
+		self.assertNotIn(update_user_language, frappe.guest_methods)
+
+
+class TestGetTranslations(LanguageTestCase):
+	def resolved_language(self) -> str:
+		"""The language get_translations picked, without loading any."""
+		with patch("buzz.api.account.get_all_translations", return_value={}) as translations:
+			get_translations()
+
+		translations.assert_called_once()
+		return translations.call_args.args[0]
+
+	def test_guest_translations_follow_the_preferred_language_cookie(self):
+		language = self.other_enabled_language()
+		self.install_request(cookies={"preferred_language": language})
+		frappe.set_user("Guest")
+
+		self.assertEqual(self.resolved_language(), language)
+
+	def test_guest_translations_fall_back_to_the_accept_language_header(self):
+		language = self.other_enabled_language()
+		self.install_request(accept_language=language)
+		frappe.set_user("Guest")
+
+		self.assertEqual(self.resolved_language(), language)
+
+	def test_guest_translations_fall_back_to_the_site_default(self):
+		self.install_request()
+		frappe.set_user("Guest")
+
+		self.assertEqual(self.resolved_language(), self.default_language())
+
+	def test_logged_in_translations_follow_the_user_document(self):
+		language = self.other_enabled_language()
+		self.set_user_language(language)
+
+		self.assertEqual(self.resolved_language(), language)
+
+	def test_a_user_without_a_language_gets_the_site_default(self):
+		self.set_user_language(None)
+
+		self.assertEqual(self.resolved_language(), self.default_language())

--- a/dashboard/src/components/LanguageSwitcher.vue
+++ b/dashboard/src/components/LanguageSwitcher.vue
@@ -15,30 +15,6 @@
 				</div>
 			</Button>
 		</template>
-		<template #item="{ item }">
-			<button
-				type="button"
-				class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-base focus:outline-none data-[highlighted]:bg-surface-gray-3"
-				:lang="(item as LanguageOption).code"
-				role="menuitemradio"
-				:aria-checked="(item as LanguageOption).isActive ? 'true' : 'false'"
-				:data-testid="`language-option-${(item as LanguageOption).code}`"
-			>
-				<Check
-					class="h-4 w-4 shrink-0"
-					:class="(item as LanguageOption).isActive ? 'text-ink-gray-9' : 'invisible'"
-				/>
-				<span
-					class="whitespace-nowrap"
-					:class="
-						(item as LanguageOption).isActive
-							? 'font-medium text-ink-gray-9'
-							: 'text-ink-gray-7'
-					"
-					>{{ item.label }}</span
-				>
-			</button>
-		</template>
 	</Dropdown>
 </template>
 
@@ -46,20 +22,11 @@
 import { useLanguage } from "@/composables/useLanguage";
 import { Button, Dropdown } from "frappe-ui";
 import type { Language } from "@/types";
-import { computed } from "vue";
-import Check from "~icons/lucide/check";
+import { computed, h } from "vue";
 import ChevronDown from "~icons/lucide/chevron-down";
 import Globe from "~icons/lucide/globe";
 
 const { availableLanguages, currentLanguage, changeLanguage, isSwitching } = useLanguage();
-
-// Dropdown options carry custom fields on top of frappe-ui's DropdownOption.
-interface LanguageOption {
-	label: string;
-	code: string;
-	isActive: boolean;
-	onClick: () => void;
-}
 
 const currentLanguageName = computed(() => {
 	const match = (availableLanguages.data || []).find(
@@ -77,13 +44,34 @@ const languageOptions = computed(() => {
 		return [];
 	}
 
-	return availableLanguages.data.map(
-		(lang: Language): LanguageOption => ({
-			label: lang.language_name || lang.name,
-			code: lang.language_code,
-			isActive: currentLanguage.value === lang.language_code,
+	return availableLanguages.data.map((lang: Language) => {
+		const label = lang.language_name || lang.name;
+		const isActive = currentLanguage.value === lang.language_code;
+
+		return {
+			label,
+			// The label goes through the row shell's `label` slot rather than the
+			// whole-row `item` slot: the whole-row slot remounts its element on
+			// every re-render, so mousedown and mouseup land on two different nodes
+			// and the browser never fires the click that selects the item. A touch
+			// press is unaffected, which is why this only broke with a mouse.
+			slots: {
+				label: () =>
+					h(
+						"span",
+						{
+							lang: lang.language_code,
+							"data-testid": `language-option-${lang.language_code}`,
+						},
+						label
+					),
+			},
+			// The tick marks the active language; every other row reserves the same
+			// leading space, so the list stays aligned.
+			icon: isActive ? "lucide-check" : undefined,
+			selected: isActive,
 			onClick: () => changeLanguage(lang.language_code),
-		})
-	);
+		};
+	});
 });
 </script>

--- a/dashboard/src/components/LanguageSwitcher.vue
+++ b/dashboard/src/components/LanguageSwitcher.vue
@@ -22,6 +22,7 @@
 				:lang="(item as LanguageOption).code"
 				role="menuitemradio"
 				:aria-checked="(item as LanguageOption).isActive ? 'true' : 'false'"
+				:data-testid="`language-option-${(item as LanguageOption).code}`"
 			>
 				<Check
 					class="h-4 w-4 shrink-0"

--- a/dashboard/src/components/LanguageSwitcher.vue
+++ b/dashboard/src/components/LanguageSwitcher.vue
@@ -1,7 +1,13 @@
 <template>
 	<Dropdown :options="languageOptions">
 		<template #default="{ open }">
-			<Button variant="ghost" size="md" :loading="isSwitching" :aria-label="triggerLabel">
+			<Button
+				variant="ghost"
+				size="md"
+				:loading="isSwitching"
+				:aria-label="triggerLabel"
+				data-testid="language-switcher"
+			>
 				<div class="flex items-center gap-2">
 					<Globe class="w-4 h-4" />
 					<span :lang="currentLanguage">{{ currentLanguageName }}</span>

--- a/dashboard/src/components/LanguageSwitcher.vue
+++ b/dashboard/src/components/LanguageSwitcher.vue
@@ -50,24 +50,23 @@ const languageOptions = computed(() => {
 
 		return {
 			label,
-			// The label goes through the row shell's `label` slot rather than the
-			// whole-row `item` slot: the whole-row slot remounts its element on
-			// every re-render, so mousedown and mouseup land on two different nodes
-			// and the browser never fires the click that selects the item. A touch
-			// press is unaffected, which is why this only broke with a mouse.
+			// The row shell's `label` slot, not the whole-row `item` slot: that one
+			// remounts its element on every re-render, so mousedown and mouseup land
+			// on different nodes and the browser never fires a click.
 			slots: {
 				label: () =>
 					h(
 						"span",
 						{
+							class: "whitespace-nowrap",
 							lang: lang.language_code,
 							"data-testid": `language-option-${lang.language_code}`,
 						},
 						label
 					),
 			},
-			// The tick marks the active language; every other row reserves the same
-			// leading space, so the list stays aligned.
+			// One icon in the group makes every row reserve the space, so the list
+			// stays aligned with a tick on only the active one.
 			icon: isActive ? "lucide-check" : undefined,
 			selected: isActive,
 			onClick: () => changeLanguage(lang.language_code),

--- a/dashboard/src/composables/useLanguage.ts
+++ b/dashboard/src/composables/useLanguage.ts
@@ -1,39 +1,123 @@
+import { session } from "@/data/session"
 import { userResource } from "@/data/user"
+import type { Language } from "@/types"
+import {
+	buildPreferredLanguageCookie,
+	readPreferredLanguage,
+	resolveRequestedLanguage,
+	takeLanguageFromQuery,
+} from "@/utils/language"
 import { createResource } from "frappe-ui"
-import { type ComputedRef, computed } from "vue"
+import { type ComputedRef, computed, watch } from "vue"
+
+// frappe-ui types `data` as `{}`; this endpoint returns Language rows.
+type LanguagesResource = Omit<ReturnType<typeof createResource>, "data"> & {
+	data?: Language[]
+}
 
 interface LanguageComposable {
-	availableLanguages: any
+	availableLanguages: LanguagesResource
 	currentLanguage: ComputedRef<string>
 	changeLanguage: (languageCode: string) => void
 	isSwitching: ComputedRef<boolean>
 }
 
-export function useLanguage(): LanguageComposable {
-	const availableLanguages = createResource({
-		url: "buzz.api.account.get_enabled_languages",
-		auto: true,
-		cache: "enabled_languages",
-	})
+// One resource for every caller: the list cannot change within a page load, and
+// applyLanguageFromQuery needs the same data the switcher renders. Created on
+// first use rather than at import — `auto: true` fetches straight away, and
+// main.ts has to install frappe-ui's resource fetcher first.
+let languagesResource: LanguagesResource | null = null
 
-	const currentLanguage = computed(() => {
-		return userResource.data?.language || "en"
-	})
+function availableLanguages(): LanguagesResource {
+	if (!languagesResource) {
+		languagesResource = createResource({
+			url: "buzz.api.account.get_enabled_languages",
+			auto: true,
+			cache: "enabled_languages",
+		}) as LanguagesResource
+	}
+	return languagesResource
+}
 
-	const switchLanguage = createResource({
-		url: "buzz.api.account.update_user_language",
-		onSuccess() {
-			// Reload the page to apply new translations
-			window.location.reload()
-		},
-	})
+const switchLanguage = createResource({
+	url: "buzz.api.account.update_user_language",
+	onSuccess() {
+		// Reload the page to apply new translations
+		window.location.reload()
+	},
+})
 
-	function changeLanguage(languageCode: string) {
+// The server resolves this for both kinds of visitor — a logged-in user's User
+// document, a guest's cookie — so there is one source of truth either way.
+const currentLanguage = computed(() => userResource.data?.language || "en")
+
+function changeLanguage(languageCode: string) {
+	if (session.isLoggedIn) {
 		switchLanguage.submit({ language_code: languageCode })
+		return
 	}
 
+	// Guests all share the `Guest` User, so persisting there would hand this
+	// language to every other visitor. The cookie is per browser.
+	document.cookie = buildPreferredLanguageCookie(languageCode)
+	window.location.reload()
+}
+
+function persistRequestedLanguage(
+	requestedLanguage: string,
+	languages: Language[],
+) {
+	const languageToApply = resolveRequestedLanguage({
+		requestedLanguage,
+		isLoggedIn: session.isLoggedIn,
+		enabledLanguageCodes: languages.map((language) => language.language_code),
+		currentLanguage: readPreferredLanguage(document.cookie),
+	})
+
+	if (!languageToApply) return
+
+	document.cookie = buildPreferredLanguageCookie(languageToApply)
+	window.location.reload()
+}
+
+/**
+ * Honour `?lang=xx` on boot, so a link can be shared in a specific language.
+ *
+ * Reading and stripping happen synchronously — the router is about to run, and
+ * a redirect would carry the parameter away. Applying it has to wait for the
+ * enabled languages, which is what the requested code is validated against.
+ */
+export function applyLanguageFromQuery() {
+	const { cleanedUrl, requestedLanguage } = takeLanguageFromQuery(
+		window.location.href,
+	)
+
+	if (!requestedLanguage) return
+
+	if (cleanedUrl) {
+		window.history.replaceState(window.history.state, "", cleanedUrl)
+	}
+
+	const languages = availableLanguages()
+
+	if (languages.data) {
+		persistRequestedLanguage(requestedLanguage, languages.data)
+		return
+	}
+
+	watch(
+		() => languages.data,
+		(loadedLanguages: Language[] | undefined) => {
+			if (loadedLanguages)
+				persistRequestedLanguage(requestedLanguage, loadedLanguages)
+		},
+		{ once: true },
+	)
+}
+
+export function useLanguage(): LanguageComposable {
 	return {
-		availableLanguages,
+		availableLanguages: availableLanguages(),
 		currentLanguage,
 		changeLanguage,
 		isSwitching: computed(() => switchLanguage.loading),

--- a/dashboard/src/composables/useLanguage.ts
+++ b/dashboard/src/composables/useLanguage.ts
@@ -24,21 +24,15 @@ interface LanguageComposable {
 	isSwitching: ComputedRef<boolean>
 }
 
-// One resource for every caller: the list cannot change within a page load, and
-// applyLanguageFromQuery needs the same data the switcher renders. Created on
-// first use rather than at import — `auto: true` fetches straight away, and
-// main.ts has to install frappe-ui's resource fetcher first.
-let languagesResource: LanguagesResource | null = null
-
+// The cache key hands every caller the same resource. Built on call rather than
+// at import: `auto: true` fetches straight away, and main.ts has to install
+// frappe-ui's resource fetcher first.
 function availableLanguages(): LanguagesResource {
-	if (!languagesResource) {
-		languagesResource = createResource({
-			url: "buzz.api.account.get_enabled_languages",
-			auto: true,
-			cache: "enabled_languages",
-		}) as LanguagesResource
-	}
-	return languagesResource
+	return createResource({
+		url: "buzz.api.account.get_enabled_languages",
+		auto: true,
+		cache: "enabled_languages",
+	}) as LanguagesResource
 }
 
 const switchLanguage = createResource({
@@ -49,8 +43,7 @@ const switchLanguage = createResource({
 	},
 })
 
-// The server resolves this for both kinds of visitor — a logged-in user's User
-// document, a guest's cookie — so there is one source of truth either way.
+// Resolved server-side for both kinds of visitor, so there is one source of truth.
 const currentLanguage = computed(() => userResource.data?.language || "en")
 
 function changeLanguage(languageCode: string) {
@@ -59,8 +52,7 @@ function changeLanguage(languageCode: string) {
 		return
 	}
 
-	// Guests all share the `Guest` User, so persisting there would hand this
-	// language to every other visitor. The cookie is per browser.
+	// Guests share the one `Guest` User; the cookie is per browser.
 	document.cookie = buildPreferredLanguageCookie(languageCode)
 	window.location.reload()
 }
@@ -80,20 +72,17 @@ function persistRequestedLanguage(
 
 	document.cookie = buildPreferredLanguageCookie(languageToApply)
 
-	// Navigating to the cleaned URL both drops the parameter and reloads for the
-	// new translations. The page is torn down either way, so writing the address
-	// bar directly is safe here.
+	// Navigating to the cleaned URL drops the parameter and reloads for the new
+	// translations in one go.
 	const { cleanedUrl } = takeLanguageFromQuery(window.location.href)
 	window.location.replace(cleanedUrl ?? window.location.href)
 }
 
 /**
- * Drop `?lang` through the router rather than history.replaceState.
- *
- * The router captures the location when it is created and writes it back on its
- * first navigation, so a replaceState before that gets undone; going through
- * the router also keeps its `currentRoute.query` in step with the address bar,
- * so a later push that spreads the existing query cannot resurrect the value.
+ * Drop `?lang` through the router, not history.replaceState: the router captures
+ * the location when it is created and writes it back on its first navigation,
+ * undoing anything done before that. It also keeps `currentRoute.query` in step,
+ * so a later push spreading the query cannot resurrect the value.
  */
 function stripLanguageQueryParam(router: Router) {
 	const route = router.currentRoute.value
@@ -105,11 +94,9 @@ function stripLanguageQueryParam(router: Router) {
 }
 
 /**
- * Honour `?lang=xx` on boot, so a link can be shared in a specific language.
- *
- * The parameter is read synchronously — the router is about to run and may
- * redirect — but applying it has to wait for the enabled languages, which is
- * what the requested code is validated against.
+ * Honour `?lang=xx` on boot, so a link can be shared in a specific language. The
+ * parameter is read synchronously — the router is about to run and may redirect
+ * — but applying it waits for the enabled languages it is validated against.
  */
 export function applyLanguageFromQuery(router: Router) {
 	const { requestedLanguage } = takeLanguageFromQuery(window.location.href)

--- a/dashboard/src/composables/useLanguage.ts
+++ b/dashboard/src/composables/useLanguage.ts
@@ -2,6 +2,7 @@ import { session } from "@/data/session"
 import { userResource } from "@/data/user"
 import type { Language } from "@/types"
 import {
+	LANGUAGE_QUERY_PARAM,
 	buildPreferredLanguageCookie,
 	readPreferredLanguage,
 	resolveRequestedLanguage,
@@ -9,6 +10,7 @@ import {
 } from "@/utils/language"
 import { createResource } from "frappe-ui"
 import { type ComputedRef, computed, watch } from "vue"
+import type { Router } from "vue-router"
 
 // frappe-ui types `data` as `{}`; this endpoint returns Language rows.
 type LanguagesResource = Omit<ReturnType<typeof createResource>, "data"> & {
@@ -77,26 +79,44 @@ function persistRequestedLanguage(
 	if (!languageToApply) return
 
 	document.cookie = buildPreferredLanguageCookie(languageToApply)
-	window.location.reload()
+
+	// Navigating to the cleaned URL both drops the parameter and reloads for the
+	// new translations. The page is torn down either way, so writing the address
+	// bar directly is safe here.
+	const { cleanedUrl } = takeLanguageFromQuery(window.location.href)
+	window.location.replace(cleanedUrl ?? window.location.href)
+}
+
+/**
+ * Drop `?lang` through the router rather than history.replaceState.
+ *
+ * The router captures the location when it is created and writes it back on its
+ * first navigation, so a replaceState before that gets undone; going through
+ * the router also keeps its `currentRoute.query` in step with the address bar,
+ * so a later push that spreads the existing query cannot resurrect the value.
+ */
+function stripLanguageQueryParam(router: Router) {
+	const route = router.currentRoute.value
+
+	if (!(LANGUAGE_QUERY_PARAM in route.query)) return
+
+	const { [LANGUAGE_QUERY_PARAM]: _applied, ...query } = route.query
+	router.replace({ path: route.path, query, hash: route.hash })
 }
 
 /**
  * Honour `?lang=xx` on boot, so a link can be shared in a specific language.
  *
- * Reading and stripping happen synchronously — the router is about to run, and
- * a redirect would carry the parameter away. Applying it has to wait for the
- * enabled languages, which is what the requested code is validated against.
+ * The parameter is read synchronously — the router is about to run and may
+ * redirect — but applying it has to wait for the enabled languages, which is
+ * what the requested code is validated against.
  */
-export function applyLanguageFromQuery() {
-	const { cleanedUrl, requestedLanguage } = takeLanguageFromQuery(
-		window.location.href,
-	)
+export function applyLanguageFromQuery(router: Router) {
+	const { requestedLanguage } = takeLanguageFromQuery(window.location.href)
 
 	if (!requestedLanguage) return
 
-	if (cleanedUrl) {
-		window.history.replaceState(window.history.state, "", cleanedUrl)
-	}
+	router.isReady().then(() => stripLanguageQueryParam(router))
 
 	const languages = availableLanguages()
 

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue"
 
 import App from "./App.vue"
+import { applyLanguageFromQuery } from "./composables/useLanguage"
 import router from "./router"
 import { initSocket } from "./socket"
 
@@ -35,6 +36,10 @@ const globalComponents = {
 const app = createApp(App)
 
 setConfig("resourceFetcher", frappeRequest)
+
+// Before the router reads the address bar: a `?lang=` link is a one-shot
+// instruction that gets applied and then stripped.
+applyLanguageFromQuery()
 
 app.use(router)
 app.use(translationPlugin)

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -37,9 +37,9 @@ const app = createApp(App)
 
 setConfig("resourceFetcher", frappeRequest)
 
-// Before the router reads the address bar: a `?lang=` link is a one-shot
+// Read before the router runs and may redirect: a `?lang=` link is a one-shot
 // instruction that gets applied and then stripped.
-applyLanguageFromQuery()
+applyLanguageFromQuery(router)
 
 app.use(router)
 app.use(translationPlugin)

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -37,8 +37,7 @@ const app = createApp(App)
 
 setConfig("resourceFetcher", frappeRequest)
 
-// Read before the router runs and may redirect: a `?lang=` link is a one-shot
-// instruction that gets applied and then stripped.
+// Before the router runs and may redirect away from the query.
 applyLanguageFromQuery(router)
 
 app.use(router)

--- a/dashboard/src/utils/language.test.ts
+++ b/dashboard/src/utils/language.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import {
+	buildPreferredLanguageCookie,
+	readPreferredLanguage,
+	resolveRequestedLanguage,
+	takeLanguageFromQuery,
+} from "./language.ts"
+
+const enabledLanguageCodes = ["en", "de", "fr"]
+
+function resolve(
+	requestedLanguage: string,
+	overrides: Record<string, unknown> = {},
+) {
+	return resolveRequestedLanguage({
+		requestedLanguage,
+		isLoggedIn: false,
+		enabledLanguageCodes,
+		currentLanguage: null,
+		...overrides,
+	})
+}
+
+test("a URL without ?lang is left untouched", () => {
+	assert.deepEqual(
+		takeLanguageFromQuery("https://buzz.test/b/account/bookings"),
+		{
+			cleanedUrl: null,
+			requestedLanguage: null,
+		},
+	)
+})
+
+test("?lang is read off the URL and stripped from it", () => {
+	assert.deepEqual(
+		takeLanguageFromQuery("https://buzz.test/b/register/pycon?lang=de"),
+		{
+			cleanedUrl: "https://buzz.test/b/register/pycon",
+			requestedLanguage: "de",
+		},
+	)
+})
+
+test("stripping ?lang keeps the other query parameters and the hash", () => {
+	assert.deepEqual(
+		takeLanguageFromQuery(
+			"https://buzz.test/b/register/pycon?lang=de&coupon=EARLY#tickets",
+		),
+		{
+			cleanedUrl: "https://buzz.test/b/register/pycon?coupon=EARLY#tickets",
+			requestedLanguage: "de",
+		},
+	)
+})
+
+test("an empty ?lang is treated as absent", () => {
+	assert.deepEqual(takeLanguageFromQuery("https://buzz.test/b?lang="), {
+		cleanedUrl: null,
+		requestedLanguage: null,
+	})
+})
+
+test("an enabled language is applied for a guest", () => {
+	assert.equal(resolve("de"), "de")
+})
+
+test("?lang is ignored for a logged-in user", () => {
+	// A shared link must not silently rewrite someone's saved preference.
+	assert.equal(resolve("de", { isLoggedIn: true }), null)
+})
+
+test("an unknown language code is never written to the cookie", () => {
+	assert.equal(resolve("not-a-language"), null)
+})
+
+test("?lang matching the language already in effect changes nothing", () => {
+	assert.equal(resolve("de", { currentLanguage: "de" }), null)
+})
+
+test("reads the preferred language out of a cookie string", () => {
+	assert.equal(
+		readPreferredLanguage("sid=abc123; preferred_language=de; user_id=Guest"),
+		"de",
+	)
+	assert.equal(readPreferredLanguage("sid=abc123"), null)
+	assert.equal(readPreferredLanguage(""), null)
+})
+
+test("the cookie is written for the whole site and survives the session", () => {
+	const cookie = buildPreferredLanguageCookie("de")
+
+	assert.match(cookie, /^preferred_language=de;/)
+	assert.match(cookie, /path=\//)
+	assert.match(cookie, /max-age=\d+/)
+	assert.match(cookie, /SameSite=Lax/)
+})

--- a/dashboard/src/utils/language.test.ts
+++ b/dashboard/src/utils/language.test.ts
@@ -87,6 +87,13 @@ test("reads the preferred language out of a cookie string", () => {
 	assert.equal(readPreferredLanguage(""), null)
 })
 
+test("a value in a neighbouring cookie is not mistaken for ours", () => {
+	assert.equal(
+		readPreferredLanguage("full_name=a&preferred_language=de; sid=abc123"),
+		null,
+	)
+})
+
 test("the cookie is written for the whole site and survives the session", () => {
 	const cookie = buildPreferredLanguageCookie("de")
 

--- a/dashboard/src/utils/language.ts
+++ b/dashboard/src/utils/language.ts
@@ -1,21 +1,25 @@
-// Guests have no User document to hold a language preference — every visitor
-// shares the one `Guest` user — so their choice lives in the
-// `preferred_language` cookie that frappe.translate.get_language() reads on
-// each request. A cookie is per browser, so one visitor's choice cannot leak
-// into another's session.
-//
-// Everything here is pure so it can be unit tested; useLanguage owns the
-// document/window side effects.
+// Every visitor shares the one `Guest` user, so a guest's language lives in the
+// `preferred_language` cookie that frappe.translate.get_language() reads per
+// request — a cookie is per browser, so one choice cannot leak into another
+// visitor's session. Kept pure for unit testing; useLanguage owns the side
+// effects.
 
 export const PREFERRED_LANGUAGE_COOKIE = "preferred_language"
 export const LANGUAGE_QUERY_PARAM = "lang"
 
-// A year, so a returning visitor keeps the language they picked.
 const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 
 export function readPreferredLanguage(cookieString: string): string | null {
-	const cookies = new URLSearchParams(cookieString.split("; ").join("&"))
-	return cookies.get(PREFERRED_LANGUAGE_COOKIE)
+	// Split on the separator rather than reusing URLSearchParams: another
+	// cookie's value is free to contain an `&`, and would be read as ours.
+	for (const cookie of cookieString.split(";")) {
+		const [name, ...value] = cookie.split("=")
+		if (name.trim() === PREFERRED_LANGUAGE_COOKIE) {
+			return decodeURIComponent(value.join("="))
+		}
+	}
+
+	return null
 }
 
 export function buildPreferredLanguageCookie(languageCode: string): string {
@@ -31,11 +35,8 @@ export interface LanguageQueryRequest {
 }
 
 /**
- * Pull `?lang=xx` off a URL.
- *
- * The parameter is a one-shot instruction carried by a shared link, so it is
- * always removed — leaving it in place would re-pin the language on every
- * later reload, and the router is free to drop the query on its next redirect.
+ * Pull `?lang=xx` off a URL. Always removed: left in place it would re-pin the
+ * language on every later reload.
  */
 export function takeLanguageFromQuery(url: string): LanguageQueryRequest {
 	const parsedUrl = new URL(url)
@@ -72,8 +73,8 @@ export function resolveRequestedLanguage({
 	// A shared link must not silently rewrite someone's saved preference.
 	if (isLoggedIn) return null
 
-	// Never hand an unvalidated value to the cookie: whatever lands there is
-	// what the server resolves translations against.
+	// Whatever lands in the cookie is what the server resolves translations
+	// against, so it is never written unvalidated.
 	if (!enabledLanguageCodes.includes(requestedLanguage)) return null
 
 	// Already in effect — nothing to write, and no reason to reload.

--- a/dashboard/src/utils/language.ts
+++ b/dashboard/src/utils/language.ts
@@ -1,0 +1,83 @@
+// Guests have no User document to hold a language preference — every visitor
+// shares the one `Guest` user — so their choice lives in the
+// `preferred_language` cookie that frappe.translate.get_language() reads on
+// each request. A cookie is per browser, so one visitor's choice cannot leak
+// into another's session.
+//
+// Everything here is pure so it can be unit tested; useLanguage owns the
+// document/window side effects.
+
+export const PREFERRED_LANGUAGE_COOKIE = "preferred_language"
+export const LANGUAGE_QUERY_PARAM = "lang"
+
+// A year, so a returning visitor keeps the language they picked.
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
+export function readPreferredLanguage(cookieString: string): string | null {
+	const cookies = new URLSearchParams(cookieString.split("; ").join("&"))
+	return cookies.get(PREFERRED_LANGUAGE_COOKIE)
+}
+
+export function buildPreferredLanguageCookie(languageCode: string): string {
+	const value = encodeURIComponent(languageCode)
+	return `${PREFERRED_LANGUAGE_COOKIE}=${value}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`
+}
+
+export interface LanguageQueryRequest {
+	/** The URL with `?lang` removed, or null when there was nothing to remove. */
+	cleanedUrl: string | null
+	/** The requested language code, or null when the URL carried none. */
+	requestedLanguage: string | null
+}
+
+/**
+ * Pull `?lang=xx` off a URL.
+ *
+ * The parameter is a one-shot instruction carried by a shared link, so it is
+ * always removed — leaving it in place would re-pin the language on every
+ * later reload, and the router is free to drop the query on its next redirect.
+ */
+export function takeLanguageFromQuery(url: string): LanguageQueryRequest {
+	const parsedUrl = new URL(url)
+	const requestedLanguage = parsedUrl.searchParams.get(LANGUAGE_QUERY_PARAM)
+
+	if (!requestedLanguage) {
+		return { cleanedUrl: null, requestedLanguage: null }
+	}
+
+	parsedUrl.searchParams.delete(LANGUAGE_QUERY_PARAM)
+
+	return { cleanedUrl: parsedUrl.toString(), requestedLanguage }
+}
+
+export interface RequestedLanguageInput {
+	requestedLanguage: string
+	isLoggedIn: boolean
+	/** Codes of the languages enabled on the site, from get_enabled_languages. */
+	enabledLanguageCodes: string[]
+	/** The language already in effect for this browser, if any. */
+	currentLanguage: string | null
+}
+
+/**
+ * Decide whether a requested language should be persisted for this visitor.
+ * Returns the code to write, or null when nothing should change.
+ */
+export function resolveRequestedLanguage({
+	requestedLanguage,
+	isLoggedIn,
+	enabledLanguageCodes,
+	currentLanguage,
+}: RequestedLanguageInput): string | null {
+	// A shared link must not silently rewrite someone's saved preference.
+	if (isLoggedIn) return null
+
+	// Never hand an unvalidated value to the cookie: whatever lands there is
+	// what the server resolves translations against.
+	if (!enabledLanguageCodes.includes(requestedLanguage)) return null
+
+	// Already in effect — nothing to write, and no reason to reload.
+	if (requestedLanguage === currentLanguage) return null
+
+	return requestedLanguage
+}

--- a/e2e/tests/language.setup.ts
+++ b/e2e/tests/language.setup.ts
@@ -2,9 +2,8 @@ import { test as setup } from "@playwright/test";
 import { getDoc, updateDoc } from "../helpers/frappe";
 
 /**
- * The language specs need a second enabled language to switch to. German ships
- * with every Frappe site; enabling it here keeps the specs from depending on
- * whatever the site happens to have turned on.
+ * The specs need a second language to switch to. German ships with every Frappe
+ * site, so enabling it beats depending on whatever the site has turned on.
  */
 setup("enable a second language", async ({ request }) => {
 	const language = await getDoc<{ enabled: number }>(request, "Language", "de");

--- a/e2e/tests/language.setup.ts
+++ b/e2e/tests/language.setup.ts
@@ -1,0 +1,16 @@
+import { test as setup } from "@playwright/test";
+import { getDoc, updateDoc } from "../helpers/frappe";
+
+/**
+ * The language specs need a second enabled language to switch to. German ships
+ * with every Frappe site; enabling it here keeps the specs from depending on
+ * whatever the site happens to have turned on.
+ */
+setup("enable a second language", async ({ request }) => {
+	const language = await getDoc<{ enabled: number }>(request, "Language", "de");
+
+	if (!language.enabled) {
+		await updateDoc(request, "Language", "de", { enabled: 1 });
+		console.log("🌍 Enabled the German language for the language specs");
+	}
+});

--- a/e2e/tests/language.spec.ts
+++ b/e2e/tests/language.spec.ts
@@ -1,0 +1,90 @@
+import { type Page, expect, test } from "@playwright/test";
+
+// Enabled by language.setup.ts.
+const TARGET_LANGUAGE = "de";
+
+const switcher = (page: Page) => page.getByTestId("language-switcher");
+const activeLanguage = (page: Page) => switcher(page).locator("span[lang]");
+
+async function preferredLanguageCookie(page: Page): Promise<string | undefined> {
+	const cookies = await page.context().cookies();
+	return cookies.find((cookie) => cookie.name === "preferred_language")?.value;
+}
+
+test.describe("Language switcher — guest", () => {
+	test.use({ storageState: { cookies: [], origins: [] } });
+
+	test("switching language stores a cookie instead of calling the account API", async ({
+		page,
+	}) => {
+		// Every guest shares the one `Guest` User, so the endpoint that writes to
+		// it is not whitelisted for guests — it used to return a PermissionError.
+		const userLanguageCalls: string[] = [];
+		page.on("request", (request) => {
+			if (request.url().includes("update_user_language")) {
+				userLanguageCalls.push(request.url());
+			}
+		});
+
+		await page.goto("/b");
+		await page.waitForLoadState("networkidle");
+
+		await expect(switcher(page)).toBeVisible();
+		await switcher(page).click();
+		await page.locator(`[role="menuitemradio"][lang="${TARGET_LANGUAGE}"]`).click();
+
+		await expect(activeLanguage(page)).toHaveAttribute("lang", TARGET_LANGUAGE);
+		expect(await preferredLanguageCookie(page)).toBe(TARGET_LANGUAGE);
+		expect(userLanguageCalls).toEqual([]);
+	});
+
+	test("the chosen language survives a fresh page load", async ({ page }) => {
+		await page.goto("/b");
+		await page.waitForLoadState("networkidle");
+
+		await switcher(page).click();
+		await page.locator(`[role="menuitemradio"][lang="${TARGET_LANGUAGE}"]`).click();
+		await expect(activeLanguage(page)).toHaveAttribute("lang", TARGET_LANGUAGE);
+
+		await page.goto("/b");
+		await expect(activeLanguage(page)).toHaveAttribute("lang", TARGET_LANGUAGE);
+	});
+
+	test("?lang pins the language and disappears from the URL", async ({ page }) => {
+		await page.goto(`/b?lang=${TARGET_LANGUAGE}`);
+
+		await expect(activeLanguage(page)).toHaveAttribute("lang", TARGET_LANGUAGE);
+		expect(await preferredLanguageCookie(page)).toBe(TARGET_LANGUAGE);
+		// Left in place it would re-pin the language on every later reload.
+		await expect
+			.poll(() => new URL(page.url()).searchParams.has("lang"))
+			.toBe(false);
+	});
+
+	test("an unknown ?lang value is never written to the cookie", async ({ page }) => {
+		await page.goto("/b?lang=not-a-language");
+		await page.waitForLoadState("networkidle");
+
+		await expect(switcher(page)).toBeVisible();
+		await expect(activeLanguage(page)).not.toHaveAttribute("lang", "not-a-language");
+		expect(await preferredLanguageCookie(page)).toBeUndefined();
+		await expect
+			.poll(() => new URL(page.url()).searchParams.has("lang"))
+			.toBe(false);
+	});
+});
+
+test.describe("Language switcher — logged in", () => {
+	test("?lang does not rewrite a saved language preference", async ({ page }) => {
+		await page.goto(`/b?lang=${TARGET_LANGUAGE}`);
+		await page.waitForLoadState("networkidle");
+
+		// The user's own preference wins; the parameter is still stripped.
+		await expect(switcher(page)).toBeVisible();
+		await expect(activeLanguage(page)).not.toHaveAttribute("lang", TARGET_LANGUAGE);
+		expect(await preferredLanguageCookie(page)).toBeUndefined();
+		await expect
+			.poll(() => new URL(page.url()).searchParams.has("lang"))
+			.toBe(false);
+	});
+});

--- a/e2e/tests/language.spec.ts
+++ b/e2e/tests/language.spec.ts
@@ -6,6 +6,18 @@ const TARGET_LANGUAGE = "de";
 const switcher = (page: Page) => page.getByTestId("language-switcher");
 const activeLanguage = (page: Page) => switcher(page).locator("span[lang]");
 
+/**
+ * Pick a language from the open dropdown.
+ *
+ * Selected by test id rather than by role: reka-ui's menu item renders
+ * `as-child`, and its own `role="menuitem"` wins over the one the template
+ * sets, so `[role="menuitemradio"]` never matches.
+ */
+async function chooseLanguage(page: Page, languageCode: string) {
+	await switcher(page).click();
+	await page.getByTestId(`language-option-${languageCode}`).click();
+}
+
 async function preferredLanguageCookie(page: Page): Promise<string | undefined> {
 	const cookies = await page.context().cookies();
 	return cookies.find((cookie) => cookie.name === "preferred_language")?.value;
@@ -30,8 +42,7 @@ test.describe("Language switcher — guest", () => {
 		await page.waitForLoadState("networkidle");
 
 		await expect(switcher(page)).toBeVisible();
-		await switcher(page).click();
-		await page.locator(`[role="menuitemradio"][lang="${TARGET_LANGUAGE}"]`).click();
+		await chooseLanguage(page, TARGET_LANGUAGE);
 
 		await expect(activeLanguage(page)).toHaveAttribute("lang", TARGET_LANGUAGE);
 		expect(await preferredLanguageCookie(page)).toBe(TARGET_LANGUAGE);
@@ -42,8 +53,7 @@ test.describe("Language switcher — guest", () => {
 		await page.goto("/b");
 		await page.waitForLoadState("networkidle");
 
-		await switcher(page).click();
-		await page.locator(`[role="menuitemradio"][lang="${TARGET_LANGUAGE}"]`).click();
+		await chooseLanguage(page, TARGET_LANGUAGE);
 		await expect(activeLanguage(page)).toHaveAttribute("lang", TARGET_LANGUAGE);
 
 		await page.goto("/b");

--- a/e2e/tests/language.spec.ts
+++ b/e2e/tests/language.spec.ts
@@ -7,10 +7,8 @@ const switcher = (page: Page) => page.getByTestId("language-switcher");
 const activeLanguage = (page: Page) => switcher(page).locator("span[lang]");
 
 /**
- * Pick a language from the open dropdown.
- *
- * The row itself is rendered by frappe-ui, so the test id sits on the label
- * span the switcher supplies. Clicking it selects the row it belongs to.
+ * Pick a language from the open dropdown. frappe-ui renders the row, so the test
+ * id sits on the label span the switcher supplies; clicking it selects the row.
  */
 async function chooseLanguage(page: Page, languageCode: string) {
 	await switcher(page).click();
@@ -29,8 +27,7 @@ test.describe("Language switcher — guest", () => {
 	test("switching language stores a cookie instead of calling the account API", async ({
 		page,
 	}) => {
-		// Every guest shares the one `Guest` User, so the endpoint that writes to
-		// it is not whitelisted for guests — it used to return a PermissionError.
+		// The endpoint that writes to the shared `Guest` User is not open to guests.
 		const userLanguageCalls: string[] = [];
 		page.on("request", (request) => {
 			if (request.url().includes("update_user_language")) {
@@ -89,7 +86,6 @@ test.describe("Language switcher — logged in", () => {
 		await page.goto(`/b?lang=${TARGET_LANGUAGE}`);
 		await page.waitForLoadState("networkidle");
 
-		// The user's own preference wins; the parameter is still stripped.
 		await expect(switcher(page)).toBeVisible();
 		await expect(activeLanguage(page)).not.toHaveAttribute("lang", TARGET_LANGUAGE);
 		expect(await preferredLanguageCookie(page)).toBeUndefined();

--- a/e2e/tests/language.spec.ts
+++ b/e2e/tests/language.spec.ts
@@ -12,10 +12,28 @@ const activeLanguage = (page: Page) => switcher(page).locator("span[lang]");
  * Selected by test id rather than by role: reka-ui's menu item renders
  * `as-child`, and its own `role="menuitem"` wins over the one the template
  * sets, so `[role="menuitemradio"]` never matches.
+ *
+ * The menu is portalled and animates in. Until that settles a click lands on
+ * `<html>` instead of the item, which the dismissable layer treats as an
+ * outside click and closes the menu — so wait the animation out, then click
+ * past Playwright's hit-test check. `force` cannot hide a click that did
+ * nothing here: every caller asserts on the effect (cookie, label, no API
+ * call), not on the click itself.
  */
 async function chooseLanguage(page: Page, languageCode: string) {
 	await switcher(page).click();
-	await page.getByTestId(`language-option-${languageCode}`).click();
+
+	const menu = page.locator('[data-slot="content"]');
+	await expect(menu).toBeVisible();
+	await menu.evaluate((element) =>
+		Promise.all(
+			element
+				.getAnimations({ subtree: true })
+				.map((animation) => animation.finished),
+		),
+	);
+
+	await page.getByTestId(`language-option-${languageCode}`).click({ force: true });
 }
 
 async function preferredLanguageCookie(page: Page): Promise<string | undefined> {

--- a/e2e/tests/language.spec.ts
+++ b/e2e/tests/language.spec.ts
@@ -9,31 +9,13 @@ const activeLanguage = (page: Page) => switcher(page).locator("span[lang]");
 /**
  * Pick a language from the open dropdown.
  *
- * Selected by test id rather than by role: reka-ui's menu item renders
- * `as-child`, and its own `role="menuitem"` wins over the one the template
- * sets, so `[role="menuitemradio"]` never matches.
- *
- * The menu is portalled and animates in. Until that settles a click lands on
- * `<html>` instead of the item, which the dismissable layer treats as an
- * outside click and closes the menu — so wait the animation out, then click
- * past Playwright's hit-test check. `force` cannot hide a click that did
- * nothing here: every caller asserts on the effect (cookie, label, no API
- * call), not on the click itself.
+ * The row itself is rendered by frappe-ui, so the test id sits on the label
+ * span the switcher supplies. Clicking it selects the row it belongs to.
  */
 async function chooseLanguage(page: Page, languageCode: string) {
 	await switcher(page).click();
-
-	const menu = page.locator('[data-slot="content"]');
-	await expect(menu).toBeVisible();
-	await menu.evaluate((element) =>
-		Promise.all(
-			element
-				.getAnimations({ subtree: true })
-				.map((animation) => animation.finished),
-		),
-	);
-
-	await page.getByTestId(`language-option-${languageCode}`).click({ force: true });
+	await expect(page.locator('[data-slot="content"]')).toBeVisible();
+	await page.getByTestId(`language-option-${languageCode}`).click();
 }
 
 async function preferredLanguageCookie(page: Page): Promise<string | undefined> {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
 		},
 		{
 			name: "chromium",
-			testIgnore: /guest-booking|custom-forms|event-proposal|login-modal|check-in|tickets/,
+			testIgnore: /guest-booking|custom-forms|event-proposal|login-modal|check-in|tickets|language/,
 			use: {
 				...devices["Desktop Chrome"],
 				storageState: authFile,
@@ -153,6 +153,24 @@ export default defineConfig({
 				storageState: ticketsAttendeeFile,
 			},
 			dependencies: ["tickets-setup"],
+		},
+		{
+			name: "language-setup",
+			testMatch: /language\.setup\.ts/,
+			use: {
+				storageState: authFile,
+			},
+			dependencies: ["setup"],
+		},
+		{
+			// The guest specs in here drop the storage state per describe block.
+			name: "language-chromium",
+			testMatch: /language\.spec\.ts/,
+			use: {
+				...devices["Desktop Chrome"],
+				storageState: authFile,
+			},
+			dependencies: ["language-setup"],
 		},
 		{
 			name: "offline-payment-setup",


### PR DESCRIPTION
Fixes #323.

Picking a language while logged out returned a PermissionError. `update_user_language` is not guest-whitelisted, and it must not be — every guest shares the one `Guest` User, so a write there would set the language for every other visitor. Guests now switch through the `preferred_language` cookie that `frappe.translate.get_language` already reads, which is per browser.

Two defects sat behind the PermissionError and are fixed with it:

- `get_translations` read the System Settings language for guests, so a successful switch would not have changed any strings. Both it and `get_user_info` now resolve through one helper: the User document when logged in, else cookie → Accept-Language → System Settings.
- `GuestInfoResponse` carried no `language`, so the switcher label was stuck on "en" for guests whatever they picked.

Adds `?lang=xx`. The code is validated against the enabled languages before anything is written to the cookie, and the parameter is stripped once `router.isReady()` resolves — not at boot. vue-router captures the location when it is created, at import, and writes it back on its first navigation, so a boot-time `history.replaceState` is simply undone. Guests get the language persisted; for logged-in users the parameter is ignored, since a shared link must not rewrite a saved preference.

`update_user_language` also picks up `methods=["POST"]`, per the repo's convention that anything which writes is POST-only.

## The dropdown was not clickable with a mouse

Separate bug, already on develop, found while testing this: picking a language with a mouse did nothing at all — menu stayed open, nothing changed. Touch worked, which is what made it look desktop-only.

The switcher rendered its rows through frappe-ui's whole-row `#item` slot. That slot renders `<component :is="{ render: ... }" />`, and the object literal is rebuilt every render, so Vue reads it as a new component type and remounts the row instead of patching it. reka-ui updates item state on pointer interaction, so the row is destroyed and recreated on mousedown, mouseup lands on a different node, and the browser never fires the click the menu item selects on. A touch press skips the highlight path, so the node survives.

The options now use the row shell instead: `slots.label` renders through a component with a stable identity, so the row patches in place. The tick is the row's own `icon`, and `selected` carries the checked state the hand-rolled classes used to paint. Still present in frappe-ui 1.0.0-beta.47, so an upgrade is not a way out; nothing else in `dashboard/src` uses that slot.

`role="menuitemradio"` and `aria-checked` are dropped rather than ported — reka renders its own `role="menuitem"` on the row, so the pair never applied and was invalid where it landed. The current language is still announced through the trigger's aria-label.

The E2E helper loses its `force: true` and its wait for the entrance animation. Both were working around this bug, not around a slow animation: the click was landing on `<html>` because the row it had resolved was already gone.

## Testing

Unit tests for the URL/cookie logic, integration tests for each rung of the resolution order, and Playwright specs for the guest switch and both `?lang=` behaviours. `language-chromium` passes 7/7; mouse press/release, plain click and keyboard selection all verified against a built dashboard.
