### PR TITLE
chore: v2.0.0-beta.1

### DIFF
--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0-beta.0"
+__version__ = "2.0.0-beta.1"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps `buzz/__init__.py` and `package.json` to 2.0.0-beta.1. Both files carry the same semver string; `pyproject.toml` reads its version from `__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)