### PR TITLE
chore: v1.2.0

### DIFF
--- a/buzz/__init__.py
+++ b/buzz/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 import os
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-frappe-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Event Management App built on Frappe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bumps `buzz/__init__.py` and `package.json` to 1.2.0 on the stable line, covering the refund backport (#329) merged since 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)