### PR TITLE
ci: add a version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -35,21 +35,16 @@ jobs:
       - name: Bump version and push branch
         run: |
           set -euo pipefail
-          # Semver, not PEP 440: Frappe's update check parses __version__ with
-          # semantic_version, which rejects forms like "2.0.0b0". pip normalises
-          # the semver pre-release back to PEP 440, so packaging is unaffected.
+          # Semver, not PEP 440: Frappe parses __version__ with semantic_version.
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::'$VERSION' is not a semver version"
             exit 1
           fi
-          # pyproject.toml reads the version from buzz/__init__.py, and
-          # dashboard/package.json is deliberately pinned at 0.0.0.
+          # pyproject.toml reads the version from buzz/__init__.py.
           sed -i -E "s/^__version__ = \".*\"$/__version__ = \"$VERSION\"/" buzz/__init__.py
           sed -i -E "s/^  \"version\": \".*\",$/  \"version\": \"$VERSION\",/" package.json
-          # Both expressions are anchored to the exact line, so reformatting
-          # either file turns its sed into a silent no-op and lets the two
-          # versions drift apart — the drift this workflow exists to prevent.
-          # Insist that both files changed, and no others.
+          # Both are anchored to the exact line, so a reformat would silently
+          # no-op one of them and bump only the other.
           changed="$(git diff --name-only | sort | tr '\n' ' ')"
           if [ "$changed" != "buzz/__init__.py package.json " ]; then
             echo "::error::expected both version files to change, changed: ${changed:-nothing}"
@@ -59,18 +54,14 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "chore/bump-$VERSION"
           git commit -am "chore: bump version to $VERSION"
-          # Plain --force: the runner clones shallow and never fetches this
-          # branch, so --force-with-lease has no remote-tracking ref to compare
-          # against and rejects every rerun as stale. Nothing but this workflow
-          # writes to chore/bump-*.
+          # --force-with-lease has no remote-tracking ref here and rejects
+          # reruns as stale. Only this workflow writes to chore/bump-*.
           git push --force origin "chore/bump-$VERSION"
 
       - name: Link to PR form
         run: |
-          # ponytail: the workflow stops at the branch because a PR opened with
-          # GITHUB_TOKEN does not trigger other workflows, and the required
-          # checks on develop would never run, leaving the PR unmergeable.
-          # Give it a PAT and swap this step for `gh pr create` if the click
-          # ever gets annoying.
+          # ponytail: stops at the branch because a PR opened with GITHUB_TOKEN
+          # triggers no checks, leaving it unmergeable. Swap for `gh pr create`
+          # once a PAT exists.
           url="${{ github.server_url }}/${{ github.repository }}/compare/$BASE...chore/bump-$VERSION?expand=1&title=chore:%20v$VERSION"
           echo "[Open the bump PR](<$url>)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -60,8 +60,8 @@ jobs:
 
       - name: Link to PR form
         run: |
-          # ponytail: stops at the branch because a PR opened with GITHUB_TOKEN
-          # triggers no checks, leaving it unmergeable. Swap for `gh pr create`
-          # once a PAT exists.
+          # Stops at the branch because a PR opened with GITHUB_TOKEN triggers
+          # no checks, leaving it unmergeable. Swap for `gh pr create` once a
+          # PAT exists.
           url="${{ github.server_url }}/${{ github.repository }}/compare/$BASE...chore/bump-$VERSION?expand=1&title=chore:%20v$VERSION"
           echo "[Open the bump PR](<$url>)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,72 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version, e.g. 1.2.0 or 2.0.0-beta.1 (semver, no leading "v")'
+        required: true
+        type: string
+      base:
+        description: 'Branch to bump'
+        required: true
+        default: develop
+        type: choice
+        options:
+          - develop
+          - main
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Push bump branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base }}
+
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # Semver, not PEP 440: Frappe's update check parses __version__ with
+          # semantic_version, which rejects forms like "2.0.0b0". pip normalises
+          # the semver pre-release back to PEP 440, so packaging is unaffected.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$VERSION' is not a semver version"
+            exit 1
+          fi
+          # pyproject.toml reads the version from buzz/__init__.py, and
+          # dashboard/package.json is deliberately pinned at 0.0.0.
+          sed -i -E "s/^__version__ = \".*\"$/__version__ = \"$VERSION\"/" buzz/__init__.py
+          sed -i -E "s/^  \"version\": \".*\",$/  \"version\": \"$VERSION\",/" package.json
+          git diff --exit-code && { echo "::error::version is already $VERSION"; exit 1; } || true
+
+      - name: Push branch
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "chore/bump-$VERSION"
+          git commit -am "chore: bump version to $VERSION"
+          git push --force-with-lease origin "chore/bump-$VERSION"
+
+      - name: Link to PR form
+        env:
+          VERSION: ${{ inputs.version }}
+          BASE: ${{ inputs.base }}
+        run: |
+          # ponytail: the workflow stops at the branch because a PR opened with
+          # GITHUB_TOKEN does not trigger other workflows, and the required
+          # checks on develop would never run, leaving the PR unmergeable.
+          # Give it a PAT and swap this step for `gh pr create` if the click
+          # ever gets annoying.
+          url="${{ github.server_url }}/${{ github.repository }}/compare/$BASE...chore/bump-$VERSION?expand=1&title=chore:%20v$VERSION"
+          echo "[Open the bump PR](<$url>)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: write
 
+# Runs for one version share a branch name, so queue them rather than let a
+# second run force-push over the first.
+concurrency:
+  group: version-bump-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   bump:
     name: Push bump branch

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,15 +23,16 @@ jobs:
   bump:
     name: Push bump branch
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      BASE: ${{ inputs.base }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.base }}
 
-      - name: Bump version
-        env:
-          VERSION: ${{ inputs.version }}
+      - name: Bump version and push branch
         run: |
           set -euo pipefail
           # Semver, not PEP 440: Frappe's update check parses __version__ with
@@ -45,23 +46,26 @@ jobs:
           # dashboard/package.json is deliberately pinned at 0.0.0.
           sed -i -E "s/^__version__ = \".*\"$/__version__ = \"$VERSION\"/" buzz/__init__.py
           sed -i -E "s/^  \"version\": \".*\",$/  \"version\": \"$VERSION\",/" package.json
-          git diff --exit-code && { echo "::error::version is already $VERSION"; exit 1; } || true
-
-      - name: Push branch
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
+          # Both expressions are anchored to the exact line, so reformatting
+          # either file turns its sed into a silent no-op and lets the two
+          # versions drift apart — the drift this workflow exists to prevent.
+          # Insist that both files changed, and no others.
+          changed="$(git diff --name-only | sort | tr '\n' ' ')"
+          if [ "$changed" != "buzz/__init__.py package.json " ]; then
+            echo "::error::expected both version files to change, changed: ${changed:-nothing}"
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "chore/bump-$VERSION"
           git commit -am "chore: bump version to $VERSION"
-          git push --force-with-lease origin "chore/bump-$VERSION"
+          # Plain --force: the runner clones shallow and never fetches this
+          # branch, so --force-with-lease has no remote-tracking ref to compare
+          # against and rejects every rerun as stale. Nothing but this workflow
+          # writes to chore/bump-*.
+          git push --force origin "chore/bump-$VERSION"
 
       - name: Link to PR form
-        env:
-          VERSION: ${{ inputs.version }}
-          BASE: ${{ inputs.base }}
         run: |
           # ponytail: the workflow stops at the branch because a PR opened with
           # GITHUB_TOKEN does not trigger other workflows, and the required

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,10 +19,11 @@ on:
 permissions:
   contents: write
 
-# Runs for one version share a branch name, so queue them rather than let a
-# second run force-push over the first.
+# Two runs sharing a branch name would force-push over each other. The branch
+# name carries the base, so only a repeat of the same dispatch collides, and
+# that regenerates identical content — queue it rather than race it.
 concurrency:
-  group: version-bump-${{ github.event.inputs.version }}
+  group: version-bump-${{ github.event.inputs.base }}-${{ github.event.inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -58,16 +59,18 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -c "chore/bump-$VERSION"
+          # The base is part of the branch name: one version can be bumped on
+          # both lines, and the two commits must not share a branch.
+          git switch -c "chore/bump-$BASE-$VERSION"
           git commit -am "chore: bump version to $VERSION"
           # --force-with-lease has no remote-tracking ref here and rejects
           # reruns as stale. Only this workflow writes to chore/bump-*.
-          git push --force origin "chore/bump-$VERSION"
+          git push --force origin "chore/bump-$BASE-$VERSION"
 
       - name: Link to PR form
         run: |
           # Stops at the branch because a PR opened with GITHUB_TOKEN triggers
           # no checks, leaving it unmergeable. Swap for `gh pr create` once a
           # PAT exists.
-          url="${{ github.server_url }}/${{ github.repository }}/compare/$BASE...chore/bump-$VERSION?expand=1&title=chore:%20v$VERSION"
+          url="${{ github.server_url }}/${{ github.repository }}/compare/$BASE...chore/bump-$BASE-$VERSION?expand=1&title=chore:%20v$VERSION"
           echo "[Open the bump PR](<$url>)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`workflow_dispatch` job: pick a version and a base branch, it rewrites `buzz/__init__.py` and `package.json` (the only two files carrying the version — `pyproject.toml` reads `__init__.py`, `dashboard/package.json` stays pinned at 0.0.0) and pushes `chore/bump-<version>`.

It stops at the branch and puts a prefilled PR link in the run summary, rather than calling `gh pr create`. A PR opened with `GITHUB_TOKEN` does not trigger other workflows, so the required checks on develop would never run and the bump PR would sit unmergeable. Wiring in a PAT later turns that last step into one `gh pr create` call.

Input is validated as semver before anything is edited. Semver and not PEP 440 because Frappe's update check parses `__version__` with `semantic_version`, which rejects `2.0.0b0`.

Wants the `backport main` label after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)