### PR TITLE
fix(booking): validate phone numbers on the guest and custom-field paths

### DIFF
--- a/buzz/api/booking/guests.py
+++ b/buzz/api/booking/guests.py
@@ -6,7 +6,7 @@ import pyotp
 from frappe import _
 from frappe.auth import LoginAttemptTracker
 from frappe.core.doctype.sms_settings.sms_settings import send_sms
-from frappe.utils import validate_email_address
+from frappe.utils import validate_email_address, validate_phone_number_with_country_code
 
 from buzz.api.booking.exceptions import InvalidOTP, OTPExpired, TooManyOTPAttempts
 
@@ -29,6 +29,11 @@ def send_booking_otp(event: int, identifier: str) -> dict | None:
 	if channel == "email":
 		identifier = identifier.lower()
 		validate_email_address(identifier, throw=True)
+	else:
+		# Validate only, never rewrite: the OTP cache key is built from `identifier` here and
+		# rebuilt from the submitted phone in BookingService.verify_guest. Normalising on one
+		# side and not the other would silently break verification.
+		validate_phone_number_with_country_code(identifier, _("Phone Number"))
 
 	otp_secret = b32encode(os.urandom(10)).decode("utf-8")
 	otp_code = pyotp.HOTP(otp_secret).at(0)

--- a/buzz/api/booking/guests.py
+++ b/buzz/api/booking/guests.py
@@ -30,9 +30,8 @@ def send_booking_otp(event: int, identifier: str) -> dict | None:
 		identifier = identifier.lower()
 		validate_email_address(identifier, throw=True)
 	else:
-		# Validate only, never rewrite: the OTP cache key is built from `identifier` here and
-		# rebuilt from the submitted phone in BookingService.verify_guest. Normalising on one
-		# side and not the other would silently break verification.
+		# Validate only, never rewrite: the cache key below is rebuilt from the submitted
+		# phone in BookingService.verify_guest, so normalising here would break verification.
 		validate_phone_number_with_country_code(identifier, _("Phone Number"))
 
 	otp_secret = b32encode(os.urandom(10)).decode("utf-8")

--- a/buzz/api/booking/services.py
+++ b/buzz/api/booking/services.py
@@ -1,6 +1,5 @@
 import hashlib
 import hmac
-from functools import cached_property
 from typing import TYPE_CHECKING
 
 import frappe
@@ -44,6 +43,7 @@ class BookingService:
 
 	def process(self) -> FreeBookingResponse | OfflineBookingResponse | PaymentLinkResponse:
 		self.validate_event()
+		self.validate_phone_fields()
 		booking = self.build_booking()
 		booking.insert(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
@@ -54,6 +54,18 @@ class BookingService:
 			frappe.throw(_("Event is not live"))
 		if are_registrations_closed(self.event):
 			RegistrationsClosed.throw()
+
+	def validate_phone_fields(self) -> None:
+		"""Validate every Phone custom field, booking-level and attendee-level, before
+		anything with a side effect runs.
+
+		verify_guest_otp deletes the code from the cache, and no rollback puts it back, so a
+		phone rejected later in build_booking would cost the guest a fresh OTP.
+		"""
+		phone_field_map = self.phone_field_labels()
+		validate_custom_fields(self.request.booking_custom_fields or {}, phone_field_map)
+		for attendee in self.request.attendees:
+			validate_custom_fields(attendee.get("custom_fields") or {}, phone_field_map)
 
 	def build_booking(self) -> "EventBooking":
 		booking = frappe.new_doc("Event Booking")
@@ -120,7 +132,6 @@ class BookingService:
 	def append_custom_fields(self, booking: "EventBooking") -> None:
 		if not self.request.booking_custom_fields:
 			return
-		validate_custom_fields(self.request.booking_custom_fields, self.phone_field_labels)
 		definitions = frappe.db.get_all(
 			"Buzz Custom Field",
 			filters={"event": self.request.event, "enabled": 1, "applied_to": "Booking"},
@@ -143,9 +154,8 @@ class BookingService:
 
 	def append_attendees(self, booking: "EventBooking") -> None:
 		self.validate_zoom_last_names()
-		phone_field_map = self.phone_field_labels
 		for attendee in self.request.attendees:
-			booking.append("attendees", self.attendee_row(attendee, phone_field_map))
+			booking.append("attendees", self.attendee_row(attendee))
 
 	def validate_zoom_last_names(self) -> None:
 		if self.event.category not in ZOOM_BACKED_CATEGORIES:
@@ -154,13 +164,9 @@ class BookingService:
 			if not (attendee.get("last_name") or "").strip():
 				frappe.throw(_("Last name is required for all attendees in Zoom events"))
 
-	@cached_property
 	def phone_field_labels(self) -> dict:
-		"""Label by fieldname for every Phone custom field on the event.
-
-		Not filtered on `applied_to`, so it covers booking-level and attendee-level fields alike.
-		Cached because both append paths need it and the rows cannot change mid-request.
-		"""
+		"""Label by fieldname for every Phone custom field on the event, booking- and
+		attendee-level alike, so `applied_to` is deliberately not filtered on."""
 		phone_fields = frappe.db.get_all(
 			"Buzz Custom Field",
 			filters={"event": self.request.event, "enabled": 1, "fieldtype": "Phone"},
@@ -168,7 +174,7 @@ class BookingService:
 		)
 		return {field.fieldname: field.label for field in phone_fields}
 
-	def attendee_row(self, attendee: dict, phone_field_map: dict) -> dict:
+	def attendee_row(self, attendee: dict) -> dict:
 		first_name, last_name = resolve_attendee_names(attendee)
 
 		add_ons = attendee.get("add_ons", None)
@@ -176,8 +182,6 @@ class BookingService:
 			add_ons = create_add_on_doc(f"{first_name} {last_name}".strip(), add_ons)
 
 		custom_fields = attendee.get("custom_fields", {})
-		if custom_fields:
-			validate_custom_fields(custom_fields, phone_field_map)
 
 		return {
 			"first_name": first_name,

--- a/buzz/api/booking/services.py
+++ b/buzz/api/booking/services.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import frappe
@@ -90,7 +91,9 @@ class BookingService:
 			return
 		if not self.request.guest_phone:
 			frappe.throw(_("Phone number is required"))
-		verify_guest_otp("phone", self.request.guest_phone.strip(), self.request.otp)
+		guest_phone = self.request.guest_phone.strip()
+		validate_phone_number_with_country_code(guest_phone, _("Phone Number"))
+		verify_guest_otp("phone", guest_phone, self.request.otp)
 
 	def guest_full_name(self) -> str:
 		first_name = (self.request.attendees[0].get("first_name") or "").strip()
@@ -117,6 +120,7 @@ class BookingService:
 	def append_custom_fields(self, booking: "EventBooking") -> None:
 		if not self.request.booking_custom_fields:
 			return
+		validate_custom_fields(self.request.booking_custom_fields, self.phone_field_labels)
 		definitions = frappe.db.get_all(
 			"Buzz Custom Field",
 			filters={"event": self.request.event, "enabled": 1, "applied_to": "Booking"},
@@ -139,7 +143,7 @@ class BookingService:
 
 	def append_attendees(self, booking: "EventBooking") -> None:
 		self.validate_zoom_last_names()
-		phone_field_map = self.phone_field_labels()
+		phone_field_map = self.phone_field_labels
 		for attendee in self.request.attendees:
 			booking.append("attendees", self.attendee_row(attendee, phone_field_map))
 
@@ -150,7 +154,13 @@ class BookingService:
 			if not (attendee.get("last_name") or "").strip():
 				frappe.throw(_("Last name is required for all attendees in Zoom events"))
 
+	@cached_property
 	def phone_field_labels(self) -> dict:
+		"""Label by fieldname for every Phone custom field on the event.
+
+		Not filtered on `applied_to`, so it covers booking-level and attendee-level fields alike.
+		Cached because both append paths need it and the rows cannot change mid-request.
+		"""
 		phone_fields = frappe.db.get_all(
 			"Buzz Custom Field",
 			filters={"event": self.request.event, "enabled": 1, "fieldtype": "Phone"},

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -14,6 +14,7 @@ from buzz.api.forms.test_forms import ensure_prompt_named_record
 
 BOOKER = "booking-owner@example.com"
 OUTSIDER = "booking-outsider@example.com"
+VALID_PHONE = "+91-9000090000"
 
 EVENT_DATA_FIELDS = {
 	"registrations_closed",
@@ -142,6 +143,27 @@ class TestSendGuestBookingOtp(BookingTestCase):
 		self.assertTrue(response["otp"])
 		self.assertTrue(frappe.cache.get_value("guest_booking_otp:email:someone@example.com"))
 
+	def enable_phone_otp(self):
+		self.set_event({"allow_guest_booking": 1, "guest_verification_method": "Phone OTP"})
+
+	def test_alphabetic_phone_is_refused(self):
+		self.enable_phone_otp()
+		with self.assertRaises(frappe.ValidationError):
+			send_guest_booking_otp(self.event.name, "abcd")
+		self.assertFalse(frappe.cache.get_value("guest_booking_otp:phone:abcd"))
+
+	def test_phone_of_the_wrong_length_is_refused(self):
+		self.enable_phone_otp()
+		with self.assertRaises(frappe.ValidationError):
+			send_guest_booking_otp(self.event.name, "+91-12345")
+		self.assertFalse(frappe.cache.get_value("guest_booking_otp:phone:+91-12345"))
+
+	def test_valid_phone_returns_the_code(self):
+		self.enable_phone_otp()
+		response = send_guest_booking_otp(self.event.name, VALID_PHONE)
+		self.assertTrue(response["otp"])
+		self.assertTrue(frappe.cache.get_value(f"guest_booking_otp:phone:{VALID_PHONE}"))
+
 
 class TestGetEventBookingData(BookingTestCase):
 	def test_shape(self):
@@ -231,6 +253,51 @@ class TestProcessBooking(BookingTestCase):
 		)
 		self.assertEqual(booking.status, "Approval Pending")
 		self.assertEqual(booking.payment_status, "Verification Pending")
+
+
+class TestBookingPhoneCustomFields(BookingTestCase):
+	def setUp(self):
+		super().setUp()
+		self.phone_field = frappe.get_doc(
+			{
+				"doctype": "Buzz Custom Field",
+				"event": self.event.name,
+				"label": "Contact Number",
+				"fieldname": "contact_number",
+				"fieldtype": "Phone",
+				"applied_to": "Booking",
+				"enabled": 1,
+				"order": 1,
+			}
+		).insert(ignore_permissions=True)
+
+	def test_invalid_booking_level_phone_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			process_booking(self.booking_request(booking_custom_fields={"contact_number": "+91-12345"}))
+
+	def test_valid_booking_level_phone_is_stored(self):
+		payload = process_booking(
+			self.booking_request(booking_custom_fields={"contact_number": VALID_PHONE})
+		).__json__()
+		stored = frappe.db.get_value(
+			"Additional Field",
+			{"parent": payload["booking_name"], "fieldname": "contact_number"},
+			"value",
+		)
+		self.assertEqual(stored, VALID_PHONE)
+
+	def test_invalid_attendee_level_phone_is_still_refused(self):
+		frappe.db.set_value("Buzz Custom Field", self.phone_field.name, "applied_to", "Ticket")
+		attendees = [
+			{
+				"first_name": "Booker",
+				"email": "booker@example.com",
+				"ticket_type": str(self.free_ticket_type.name),
+				"custom_fields": {"contact_number": "+91-12345"},
+			}
+		]
+		with self.assertRaises(frappe.ValidationError):
+			process_booking(self.booking_request(attendees=attendees))
 
 
 class TestGetBookingDetails(BookingTestCase):

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -286,6 +286,29 @@ class TestBookingPhoneCustomFields(BookingTestCase):
 		)
 		self.assertEqual(stored, VALID_PHONE)
 
+	def test_a_rejected_phone_does_not_burn_the_guest_otp(self):
+		# The OTP lives in the cache, which no rollback restores, so phone validation has to
+		# run before verify_guest_otp deletes it — otherwise one typo costs the guest a code.
+		self.set_event({"allow_guest_booking": 1, "guest_verification_method": "Phone OTP"})
+		otp = send_guest_booking_otp(self.event.name, VALID_PHONE)["otp"]
+		cache_key = f"guest_booking_otp:phone:{VALID_PHONE}"
+		self.addCleanup(frappe.cache.delete_value, cache_key)
+
+		frappe.set_user("Guest")
+		self.addCleanup(frappe.set_user, "Administrator")
+		with self.assertRaises(frappe.ValidationError):
+			process_booking(
+				self.booking_request(
+					guest_email="guest-phone-otp@example.com",
+					guest_full_name="Guest Phone",
+					guest_phone=VALID_PHONE,
+					otp=otp,
+					booking_custom_fields={"contact_number": "+91-12345"},
+				)
+			)
+
+		self.assertTrue(frappe.cache.get_value(cache_key))
+
 	def test_invalid_attendee_level_phone_is_still_refused(self):
 		frappe.db.set_value("Buzz Custom Field", self.phone_field.name, "applied_to", "Ticket")
 		attendees = [

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -144,12 +144,12 @@
 								required
 								@blur="prefillAttendee('email')"
 							/>
-							<FormControl
+							<PhoneInput
 								v-if="props.eventDetails.guest_verification_method === 'Phone OTP'"
 								v-model="guestPhone"
-								type="tel"
 								:label="__('Phone Number')"
 								:placeholder="__('Enter your phone number')"
+								:error="guestPhoneError"
 								required
 							/>
 						</div>
@@ -435,6 +435,7 @@ import CustomFieldsSection from "./CustomFieldsSection.vue";
 import EventDetailsHeader from "./EventDetailsHeader.vue";
 import OfflinePaymentDialog from "./OfflinePaymentDialog.vue";
 import PaymentGatewayDialog from "./PaymentGatewayDialog.vue";
+import PhoneInput from "./PhoneInput.vue";
 
 const router = useRouter();
 const route = useRoute();
@@ -557,6 +558,8 @@ const successBookingName = ref("");
 const showOtpModal = ref(false);
 const otpCode = ref("");
 const otpError = ref("");
+// Server-side phone validation message, rendered under the guest Phone Number field.
+const guestPhoneError = ref("");
 const pendingBookingPayload = ref<any>(null);
 const resendCooldown = ref(0);
 let resendCooldownTimer: ReturnType<typeof setInterval> | undefined;
@@ -993,11 +996,22 @@ const sendOtpResource = createResource({
 		);
 	},
 	onError: (error: FrappeError) => {
-		toast.error(error.messages?.[0] || __("Failed to send verification code"));
+		const message = error.messages?.[0] || __("Failed to send verification code");
+		// Phone validation failures belong under the field, not in a toast that
+		// disappears before the user can act on it.
+		if (isPhoneOtp.value) {
+			guestPhoneError.value = message;
+			return;
+		}
+		toast.error(message);
 	},
 });
 
 const isPhoneOtp = computed(() => props.eventDetails.guest_verification_method === "Phone OTP");
+
+watch(guestPhone, () => {
+	guestPhoneError.value = "";
+});
 
 function sendOtpForVerification() {
 	sendOtpResource.submit({

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -558,7 +558,6 @@ const successBookingName = ref("");
 const showOtpModal = ref(false);
 const otpCode = ref("");
 const otpError = ref("");
-// Server-side phone validation message, rendered under the guest Phone Number field.
 const guestPhoneError = ref("");
 const pendingBookingPayload = ref<any>(null);
 const resendCooldown = ref(0);
@@ -997,8 +996,7 @@ const sendOtpResource = createResource({
 	},
 	onError: (error: FrappeError) => {
 		const message = error.messages?.[0] || __("Failed to send verification code");
-		// Phone validation failures belong under the field, not in a toast that
-		// disappears before the user can act on it.
+		// Under the field, not in a toast the user has to remember while retyping.
 		if (isPhoneOtp.value) {
 			guestPhoneError.value = message;
 			return;
@@ -1014,6 +1012,7 @@ watch(guestPhone, () => {
 });
 
 function sendOtpForVerification() {
+	guestPhoneError.value = "";
 	sendOtpResource.submit({
 		event: props.eventDetails.name,
 		identifier: isPhoneOtp.value ? guestPhone.value.trim() : guestEmail.value.trim(),

--- a/dashboard/src/components/PhoneInput.vue
+++ b/dashboard/src/components/PhoneInput.vue
@@ -20,12 +20,13 @@
 				:placeholder="placeholder || __('Phone number')"
 			/>
 		</div>
+		<ErrorMessage v-if="error" :message="error" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import { DEFAULT_DIAL_CODE, formatPhone, parsePhone } from "@/utils/phone";
-import { Combobox, TextInput, createResource } from "frappe-ui";
+import { Combobox, ErrorMessage, TextInput, createResource } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
 interface DialCode {
@@ -38,6 +39,9 @@ const props = defineProps({
 	label: { type: String, default: "Phone" },
 	placeholder: { type: String, default: "" },
 	required: { type: Boolean, default: false },
+	// Server-side validation message to render under the field. Callers that don't
+	// pass it render nothing, so existing usages are unchanged.
+	error: { type: String, default: "" },
 });
 
 const emit = defineEmits(["update:modelValue"]);

--- a/dashboard/src/components/PhoneInput.vue
+++ b/dashboard/src/components/PhoneInput.vue
@@ -39,8 +39,6 @@ const props = defineProps({
 	label: { type: String, default: "Phone" },
 	placeholder: { type: String, default: "" },
 	required: { type: Boolean, default: false },
-	// Server-side validation message to render under the field. Callers that don't
-	// pass it render nothing, so existing usages are unchanged.
 	error: { type: String, default: "" },
 });
 

--- a/e2e/helpers/frappe.ts
+++ b/e2e/helpers/frappe.ts
@@ -221,3 +221,32 @@ export async function docExists(
 		return false;
 	}
 }
+
+const TEST_TEAM_NAME = "E2E Team";
+
+/**
+ * Return the team every fixture stamps its documents with, creating it on first run.
+ *
+ * Team-direct doctypes (Buzz Event, Event Host, ...) make `team` mandatory and only fill
+ * it in when the acting user has exactly one membership. A dev site can hand the test user
+ * any number of teams, so fixtures name the team rather than relying on that inference.
+ *
+ * The list is already scoped to the acting user's teams, so a same-named team belonging to
+ * somebody else is invisible here and a membership comes free with the insert.
+ */
+export async function ensureTestTeam(request: APIRequestContext): Promise<string> {
+	const [existing] = await getList<{ name: string }>(request, "Buzz Team", {
+		fields: ["name"],
+		filters: { team_name: TEST_TEAM_NAME },
+		limit: 1,
+	});
+
+	if (existing) {
+		return existing.name;
+	}
+
+	const team = await createDoc<{ name: string }>(request, "Buzz Team", {
+		team_name: TEST_TEAM_NAME,
+	});
+	return team.name;
+}

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -2,7 +2,7 @@ import { test as setup, expect } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
 
-import { createDoc, getList } from "../helpers/frappe";
+import { ensureTestTeam } from "../helpers/frappe";
 
 const authFile = "e2e/.auth/user.json";
 const csrfFile = "e2e/.auth/csrf.json";
@@ -54,14 +54,7 @@ setup("authenticate", async ({ page }) => {
 	await page.context().storageState({ path: authFile });
 	console.log(`💾 Saved auth state to ${authFile}`);
 
-	// The fixtures omit `team`, which resolves from the acting user's only membership.
-	const teams = await getList(page.request, "Buzz Team Membership", {
-		filters: { user: userData.message, enabled: 1 },
-		limit: 2,
-	});
-
-	if (teams.length === 0) {
-		await createDoc(page.request, "Buzz Team", { team_name: "E2E Team" });
-		console.log("👥 Created E2E Team for the test user");
-	}
+	// Every fixture stamps this team on the documents it creates.
+	const team = await ensureTestTeam(page.request);
+	console.log(`👥 Using team ${team} for the test user`);
 });

--- a/e2e/tests/check-in.setup.ts
+++ b/e2e/tests/check-in.setup.ts
@@ -1,6 +1,6 @@
 import { test as setup } from "@playwright/test";
 import { createUserWithRoles, saveLoginState } from "../helpers/auth";
-import { callMethod, createDoc, deleteDoc, docExists, getList } from "../helpers/frappe";
+import { callMethod, createDoc, deleteDoc, docExists, ensureTestTeam, getList } from "../helpers/frappe";
 import {
 	CHECK_IN_EVENT_ROUTE,
 	CHECK_IN_EVENT_TITLE,
@@ -81,14 +81,17 @@ setup("seed check-in event, ticket type and front-desk users", async ({ request,
 		});
 	}
 
+	const team = await ensureTestTeam(request);
+
 	if (!(await docExists(request, "Event Host", HOST))) {
-		await createDoc(request, "Event Host", { name: HOST });
+		await createDoc(request, "Event Host", { name: HOST, team });
 	}
 
 	const startDate = new Date();
 	startDate.setDate(startDate.getDate() + 7);
 
-	const event = await createDoc<NamedDoc & { team: string }>(request, "Buzz Event", {
+	const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+		team,
 		title: CHECK_IN_EVENT_TITLE,
 		category: CATEGORY,
 		host: HOST,
@@ -115,7 +118,7 @@ setup("seed check-in event, ticket type and front-desk users", async ({ request,
 		roles: ["Buzz User", "Frontdesk Manager"],
 	});
 
-	await ensureTeamMembership(request, event.team, FRONTDESK_EMAIL, "Frontdesk");
+	await ensureTeamMembership(request, team, FRONTDESK_EMAIL, "Frontdesk");
 
 	await saveLoginState(baseURL!, {
 		email: FRONTDESK_EMAIL,

--- a/e2e/tests/custom-forms.setup.ts
+++ b/e2e/tests/custom-forms.setup.ts
@@ -6,7 +6,7 @@ import {
 	CUSTOM_FORMS_EVENT_ROUTE,
 	MEMBERS_ONLY_FORM_ROUTE,
 } from "../data/custom-forms";
-import { createDoc, docExists, getDoc, getList, updateDoc } from "../helpers/frappe";
+import { createDoc, docExists, ensureTestTeam, getDoc, getList, updateDoc } from "../helpers/frappe";
 
 interface NamedDoc {
 	name: string;
@@ -32,8 +32,10 @@ setup("setup custom forms on test event", async ({ request }) => {
 				slug: "e2e-test-category",
 			});
 		}
+		const team = await ensureTestTeam(request);
+
 		if (!(await docExists(request, "Event Host", testHostName))) {
-			await createDoc(request, "Event Host", { name: testHostName });
+			await createDoc(request, "Event Host", { name: testHostName, team });
 		}
 
 		const futureDate = new Date();
@@ -41,6 +43,7 @@ setup("setup custom forms on test event", async ({ request }) => {
 		const startDate = futureDate.toISOString().split("T")[0];
 
 		const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+			team,
 			title: "E2E Custom Forms Event",
 			category: testCategoryName,
 			host: testHostName,

--- a/e2e/tests/event.setup.ts
+++ b/e2e/tests/event.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup, expect } from "@playwright/test";
-import { createDoc, deleteDoc, docExists, getList } from "../helpers/frappe";
+import { createDoc, deleteDoc, docExists, ensureTestTeam, getList } from "../helpers/frappe";
 
 interface NamedDoc {
 	name: string;
@@ -63,10 +63,13 @@ setup("create test event for booking", async ({ request }) => {
 		console.log(`Created Event Category: ${testCategoryName}`);
 	}
 
+	const team = await ensureTestTeam(request);
+
 	// Create Event Host if it doesn't exist
 	if (!(await docExists(request, "Event Host", testHostName))) {
 		await createDoc(request, "Event Host", {
 			name: testHostName,
+			team,
 		});
 		console.log(`Created Event Host: ${testHostName}`);
 	}
@@ -77,6 +80,7 @@ setup("create test event for booking", async ({ request }) => {
 	const startDate = futureDate.toISOString().split("T")[0];
 
 	const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+		team,
 		title: testEventTitle,
 		category: testCategoryName,
 		host: testHostName,

--- a/e2e/tests/guest-booking.spec.ts
+++ b/e2e/tests/guest-booking.spec.ts
@@ -99,4 +99,29 @@ test.describe("Guest Booking", () => {
 
 		await expect(page.getByText("Booking Confirmed")).toBeVisible({ timeout: 30000 });
 	});
+
+	test("guest phone field rejects alphabets and short numbers", async ({ page }) => {
+		const email = `guest-phone-invalid-${uid}@test.com`;
+		const bookingPage = new BookingPage(page);
+		await bookingPage.goto("guest-phone-otp-e2e");
+		await bookingPage.waitForFormLoad();
+
+		await page.locator('input[placeholder="Enter your first name"]').fill("Test");
+		await page.locator('input[placeholder="Enter your last name"]').fill("Guest Phone");
+		await page.locator('input[placeholder="Enter your email"]').fill(email);
+		await page.locator('input[placeholder="Enter your email"]').blur();
+
+		// PhoneInput strips non-digits on input, so letters never reach the model.
+		const phoneInput = page.locator('input[placeholder="Enter your phone number"]');
+		await phoneInput.fill("abcd");
+		await expect(phoneInput).toHaveValue("");
+
+		// A well-formed but too-short number is caught by the server and reported
+		// under the field rather than as a toast.
+		await phoneInput.fill("12345");
+		await bookingPage.submit();
+
+		await expect(page.getByText("is not valid")).toBeVisible({ timeout: 10000 });
+		await expect(page.getByText("Verify Your Phone")).toBeHidden();
+	});
 });

--- a/e2e/tests/guest-booking.spec.ts
+++ b/e2e/tests/guest-booking.spec.ts
@@ -100,7 +100,7 @@ test.describe("Guest Booking", () => {
 		await expect(page.getByText("Booking Confirmed")).toBeVisible({ timeout: 30000 });
 	});
 
-	test("guest phone field rejects alphabets and short numbers", async ({ page }) => {
+	test("guest phone field rejects a number of the wrong length", async ({ page }) => {
 		const email = `guest-phone-invalid-${uid}@test.com`;
 		const bookingPage = new BookingPage(page);
 		await bookingPage.goto("guest-phone-otp-e2e");
@@ -111,13 +111,9 @@ test.describe("Guest Booking", () => {
 		await page.locator('input[placeholder="Enter your email"]').fill(email);
 		await page.locator('input[placeholder="Enter your email"]').blur();
 
-		// PhoneInput strips non-digits on input, so letters never reach the model.
+		// A well-formed but too-short number passes PhoneInput's digit filter and is
+		// caught by the server, which reports it under the field rather than as a toast.
 		const phoneInput = page.locator('input[placeholder="Enter your phone number"]');
-		await phoneInput.fill("abcd");
-		await expect(phoneInput).toHaveValue("");
-
-		// A well-formed but too-short number is caught by the server and reported
-		// under the field rather than as a toast.
 		await phoneInput.fill("12345");
 		await bookingPage.submit();
 

--- a/e2e/tests/guest-event.setup.ts
+++ b/e2e/tests/guest-event.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup } from "@playwright/test";
-import { callMethod, createDoc, docExists, getList } from "../helpers/frappe";
+import { callMethod, createDoc, docExists, ensureTestTeam, getList } from "../helpers/frappe";
 
 interface NamedDoc {
 	name: string;
@@ -103,9 +103,12 @@ setup("create guest booking test events", async ({ request }) => {
 		});
 	}
 
+	const team = await ensureTestTeam(request);
+
 	if (!(await docExists(request, "Event Host", testHostName))) {
 		await createDoc(request, "Event Host", {
 			name: testHostName,
+			team,
 		});
 	}
 
@@ -116,6 +119,7 @@ setup("create guest booking test events", async ({ request }) => {
 	// Create each guest test event with a free ticket type
 	for (const evt of guestEvents) {
 		const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+			team,
 			title: evt.title,
 			category: testCategoryName,
 			host: testHostName,

--- a/e2e/tests/offline-payment.setup.ts
+++ b/e2e/tests/offline-payment.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup } from "@playwright/test";
-import { callMethod, createDoc, docExists, getList } from "../helpers/frappe";
+import { callMethod, createDoc, docExists, ensureTestTeam, getList } from "../helpers/frappe";
 
 interface NamedDoc {
 	name: string;
@@ -82,9 +82,12 @@ setup("create offline payment test event", async ({ request }) => {
 		});
 	}
 
+	const team = await ensureTestTeam(request);
+
 	if (!(await docExists(request, "Event Host", testHostName))) {
 		await createDoc(request, "Event Host", {
 			name: testHostName,
+			team,
 		});
 	}
 
@@ -94,6 +97,7 @@ setup("create offline payment test event", async ({ request }) => {
 
 	// Create event
 	const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+		team,
 		title: offlinePaymentEvent.title,
 		category: testCategoryName,
 		host: testHostName,

--- a/e2e/tests/tickets.setup.ts
+++ b/e2e/tests/tickets.setup.ts
@@ -9,7 +9,7 @@ import {
 	TICKETS_EVENT_TITLE,
 } from "../data/tickets";
 import { createUserWithRoles, saveLoginState } from "../helpers/auth";
-import { callMethod, createDoc, deleteDoc, docExists, getList } from "../helpers/frappe";
+import { callMethod, createDoc, deleteDoc, docExists, ensureTestTeam, getList } from "../helpers/frappe";
 
 interface NamedDoc {
 	name: string;
@@ -62,8 +62,10 @@ setup("seed a ticket owned by the attendee", async ({ request, baseURL }) => {
 			slug: "e2e-tickets-category",
 		});
 	}
+	const team = await ensureTestTeam(request);
+
 	if (!(await docExists(request, "Event Host", HOST))) {
-		await createDoc(request, "Event Host", { name: HOST });
+		await createDoc(request, "Event Host", { name: HOST, team });
 	}
 
 	// Far enough out that every action window (transfer, add-ons, cancellation) is open.
@@ -71,6 +73,7 @@ setup("seed a ticket owned by the attendee", async ({ request, baseURL }) => {
 	startDate.setDate(startDate.getDate() + 60);
 
 	const event = await createDoc<NamedDoc>(request, "Buzz Event", {
+		team,
 		title: TICKETS_EVENT_TITLE,
 		category: CATEGORY,
 		host: HOST,


### PR DESCRIPTION
Fixes #325.

## Problem

On an event with `guest_verification_method = "Phone OTP"`, a guest could type `abcd` into the guest Phone Number field and submit. The server cached an OTP against `abcd` and handed it to the SMS gateway — Frappe's `validate_receiver_nos` only strips `" -()"` and only throws when the list is empty, so the string reached the provider.

Three gaps, all confirmed in the code:

1. `send_booking_otp` validated the email branch with `validate_email_address(..., throw=True)` and validated nothing in the phone branch.
2. Booking-level Phone custom fields were written to `additional_fields` raw, while attendee-level ones already went through `validate_custom_fields`.
3. The guest field was a plain `FormControl type="tel"`, which filters nothing — unlike `PhoneInput`, used everywhere else, which already strips non-digits.

## Changes

**`buzz/api/booking/guests.py`** — validate the phone branch of `send_booking_otp` with `validate_phone_number_with_country_code`. Validate only, never rewrite: the OTP cache key is built from `identifier` here and rebuilt from the submitted phone in `BookingService.verify_guest`, so normalising one side and not the other would silently break verification.

**`buzz/api/booking/services.py`** — one `validate_phone_fields`, called from `process()` before `build_booking()`, covers booking-level and attendee-level Phone custom fields. Ordering is the point: `verify_guest_otp` deletes the code from the cache and no rollback puts it back, so validating later (as `append_custom_fields` and `attendee_row` did) meant a mistyped phone cost the guest a valid OTP and a fresh round of SMS. It also left `Attendee Ticket Add-on` rows inserted for earlier attendees before a later one failed. `verify_guest` validates the guest phone at submit too, so the direct-API path is covered, not just the OTP send.

**`dashboard/src/components/BookingForm.vue`** — swap the guest phone `FormControl` for the existing `PhoneInput`. It blocks alphabets at the keystroke and emits the canonical `+91-9000090000` the validator needs to pick the right per-country length. `validate_receiver_nos` strips the hyphen before the gateway, so SMS delivery is unaffected. The placeholder is passed through explicitly because the existing e2e spec selects on it. `sendOtpForVerification` clears the error before submitting, so a delivery failure does not leave a stale message under the field on the next attempt.

**`dashboard/src/components/PhoneInput.vue`** — optional `error` prop rendering frappe-ui's `ErrorMessage` under the field. Existing callers (`CustomFieldInput.vue`, `ProposalEditDialog.vue`) pass nothing and are unchanged. No client-side phone library was added: length rules live on the server, which already owns them.

Length is deliberately left to `phonenumbers` rather than a hardcoded ten digits — the dial code picker offers every country, so a fixed length would break US, UK and others.

## E2E fixtures no longer infer a team

Second commit, needed to run the suite at all. Team-direct doctypes make `team` mandatory, and `set_team_from_sole_membership` fills it only when the acting user has exactly one enabled membership. The fixtures relied on that, which holds on a fresh CI site and nowhere else — a developer whose Administrator sits on two teams cannot create so much as an Event Host, and the guest, check-in, tickets and offline-payment projects all die in setup with `Value missing for Buzz Event: Team`.

`ensureTestTeam` finds or creates a team named "E2E Team" and returns its name for the fixtures to stamp on the twelve `Buzz Event` / `Event Host` creations. The list call is already scoped to the acting user's own teams, so a same-named team belonging to somebody else stays invisible, and `BuzzTeam.after_insert` supplies the membership.

No production code changes here. Refusing to pick a team on the user's behalf is the #312 behaviour and stays; the Desk form has always posted the field.

## Tests

- `TestSendGuestBookingOtp` — `abcd` and `+91-12345` are refused and leave no cache key; a valid number still returns the code.
- `TestBookingPhoneCustomFields` — an invalid booking-level Phone custom field is refused, a valid one persists to `additional_fields`, the attendee-level path stays gated, and a rejected phone leaves the guest's OTP in the cache. That last one fails if the validation moves back after `resolve_user`; verified by moving it and watching it fail.
- `e2e/tests/guest-booking.spec.ts` — a too-short number surfaces the message under the field rather than opening the OTP dialog.

## Verification

- `bench run-tests --module buzz.api.booking.test_booking`: 26 pass.
- `./typecheck.sh` and `pre-commit run --files` on every changed file: clean. The e2e `tsc` errors are the same 8 before and after.
- Playwright `guest-chromium` against a live site: setup passes, 5 of 7 pass. The two `guest booking with … OTP` cases fail on `expect(otp).toBeTruthy()` because `send_booking_otp` returns the code only under `frappe.in_test`, which a live `bench start` never sets. Confirmed pre-existing by stashing every change and re-running — same two failures. They pass in CI, where the whole run is a test site.

---
_Generated by [Claude Code](https://claude.ai/code/session_0169SVTCxRBMMz6kQETDUAJz)_
