### PR TITLE
fix(booking): validate phone numbers on the guest and custom-field paths (backport #335)

### DIFF
--- a/buzz/api/booking/guests.py
+++ b/buzz/api/booking/guests.py
@@ -6,7 +6,7 @@ import pyotp
 from frappe import _
 from frappe.auth import LoginAttemptTracker
 from frappe.core.doctype.sms_settings.sms_settings import send_sms
-from frappe.utils import validate_email_address
+from frappe.utils import validate_email_address, validate_phone_number_with_country_code
 
 from buzz.api.booking.exceptions import InvalidOTP, OTPExpired, TooManyOTPAttempts
 
@@ -29,6 +29,10 @@ def send_booking_otp(event: int, identifier: str) -> dict | None:
 	if channel == "email":
 		identifier = identifier.lower()
 		validate_email_address(identifier, throw=True)
+	else:
+		# Validate only, never rewrite: the cache key below is rebuilt from the submitted
+		# phone in BookingService.verify_guest, so normalising here would break verification.
+		validate_phone_number_with_country_code(identifier, _("Phone Number"))
 
 	otp_secret = b32encode(os.urandom(10)).decode("utf-8")
 	otp_code = pyotp.HOTP(otp_secret).at(0)

--- a/buzz/api/booking/services.py
+++ b/buzz/api/booking/services.py
@@ -43,6 +43,7 @@ class BookingService:
 
 	def process(self) -> FreeBookingResponse | OfflineBookingResponse | PaymentLinkResponse:
 		self.validate_event()
+		self.validate_phone_fields()
 		booking = self.build_booking()
 		booking.insert(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
@@ -53,6 +54,18 @@ class BookingService:
 			frappe.throw(_("Event is not live"))
 		if are_registrations_closed(self.event):
 			RegistrationsClosed.throw()
+
+	def validate_phone_fields(self) -> None:
+		"""Validate every Phone custom field, booking-level and attendee-level, before
+		anything with a side effect runs.
+
+		verify_guest_otp deletes the code from the cache, and no rollback puts it back, so a
+		phone rejected later in build_booking would cost the guest a fresh OTP.
+		"""
+		phone_field_map = self.phone_field_labels()
+		validate_custom_fields(self.request.booking_custom_fields or {}, phone_field_map)
+		for attendee in self.request.attendees:
+			validate_custom_fields(attendee.get("custom_fields") or {}, phone_field_map)
 
 	def build_booking(self) -> "EventBooking":
 		booking = frappe.new_doc("Event Booking")
@@ -90,7 +103,9 @@ class BookingService:
 			return
 		if not self.request.guest_phone:
 			frappe.throw(_("Phone number is required"))
-		verify_guest_otp("phone", self.request.guest_phone.strip(), self.request.otp)
+		guest_phone = self.request.guest_phone.strip()
+		validate_phone_number_with_country_code(guest_phone, _("Phone Number"))
+		verify_guest_otp("phone", guest_phone, self.request.otp)
 
 	def guest_full_name(self) -> str:
 		first_name = (self.request.attendees[0].get("first_name") or "").strip()
@@ -139,9 +154,8 @@ class BookingService:
 
 	def append_attendees(self, booking: "EventBooking") -> None:
 		self.validate_zoom_last_names()
-		phone_field_map = self.phone_field_labels()
 		for attendee in self.request.attendees:
-			booking.append("attendees", self.attendee_row(attendee, phone_field_map))
+			booking.append("attendees", self.attendee_row(attendee))
 
 	def validate_zoom_last_names(self) -> None:
 		if self.event.category not in ZOOM_BACKED_CATEGORIES:
@@ -151,6 +165,8 @@ class BookingService:
 				frappe.throw(_("Last name is required for all attendees in Zoom events"))
 
 	def phone_field_labels(self) -> dict:
+		"""Label by fieldname for every Phone custom field on the event, booking- and
+		attendee-level alike, so `applied_to` is deliberately not filtered on."""
 		phone_fields = frappe.db.get_all(
 			"Buzz Custom Field",
 			filters={"event": self.request.event, "enabled": 1, "fieldtype": "Phone"},
@@ -158,7 +174,7 @@ class BookingService:
 		)
 		return {field.fieldname: field.label for field in phone_fields}
 
-	def attendee_row(self, attendee: dict, phone_field_map: dict) -> dict:
+	def attendee_row(self, attendee: dict) -> dict:
 		first_name, last_name = resolve_attendee_names(attendee)
 
 		add_ons = attendee.get("add_ons", None)
@@ -166,8 +182,6 @@ class BookingService:
 			add_ons = create_add_on_doc(f"{first_name} {last_name}".strip(), add_ons)
 
 		custom_fields = attendee.get("custom_fields", {})
-		if custom_fields:
-			validate_custom_fields(custom_fields, phone_field_map)
 
 		return {
 			"first_name": first_name,

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -14,6 +14,7 @@ from buzz.api.forms.test_forms import ensure_prompt_named_record
 
 BOOKER = "booking-owner@example.com"
 OUTSIDER = "booking-outsider@example.com"
+VALID_PHONE = "+91-9000090000"
 
 EVENT_DATA_FIELDS = {
 	"registrations_closed",
@@ -142,6 +143,27 @@ class TestSendGuestBookingOtp(BookingTestCase):
 		self.assertTrue(response["otp"])
 		self.assertTrue(frappe.cache.get_value("guest_booking_otp:email:someone@example.com"))
 
+	def enable_phone_otp(self):
+		self.set_event({"allow_guest_booking": 1, "guest_verification_method": "Phone OTP"})
+
+	def test_alphabetic_phone_is_refused(self):
+		self.enable_phone_otp()
+		with self.assertRaises(frappe.ValidationError):
+			send_guest_booking_otp(self.event.name, "abcd")
+		self.assertFalse(frappe.cache.get_value("guest_booking_otp:phone:abcd"))
+
+	def test_phone_of_the_wrong_length_is_refused(self):
+		self.enable_phone_otp()
+		with self.assertRaises(frappe.ValidationError):
+			send_guest_booking_otp(self.event.name, "+91-12345")
+		self.assertFalse(frappe.cache.get_value("guest_booking_otp:phone:+91-12345"))
+
+	def test_valid_phone_returns_the_code(self):
+		self.enable_phone_otp()
+		response = send_guest_booking_otp(self.event.name, VALID_PHONE)
+		self.assertTrue(response["otp"])
+		self.assertTrue(frappe.cache.get_value(f"guest_booking_otp:phone:{VALID_PHONE}"))
+
 
 class TestGetEventBookingData(BookingTestCase):
 	def test_shape(self):
@@ -231,6 +253,74 @@ class TestProcessBooking(BookingTestCase):
 		)
 		self.assertEqual(booking.status, "Approval Pending")
 		self.assertEqual(booking.payment_status, "Verification Pending")
+
+
+class TestBookingPhoneCustomFields(BookingTestCase):
+	def setUp(self):
+		super().setUp()
+		self.phone_field = frappe.get_doc(
+			{
+				"doctype": "Buzz Custom Field",
+				"event": self.event.name,
+				"label": "Contact Number",
+				"fieldname": "contact_number",
+				"fieldtype": "Phone",
+				"applied_to": "Booking",
+				"enabled": 1,
+				"order": 1,
+			}
+		).insert(ignore_permissions=True)
+
+	def test_invalid_booking_level_phone_is_refused(self):
+		with self.assertRaises(frappe.ValidationError):
+			process_booking(self.booking_request(booking_custom_fields={"contact_number": "+91-12345"}))
+
+	def test_valid_booking_level_phone_is_stored(self):
+		payload = process_booking(
+			self.booking_request(booking_custom_fields={"contact_number": VALID_PHONE})
+		).__json__()
+		stored = frappe.db.get_value(
+			"Additional Field",
+			{"parent": payload["booking_name"], "fieldname": "contact_number"},
+			"value",
+		)
+		self.assertEqual(stored, VALID_PHONE)
+
+	def test_a_rejected_phone_does_not_burn_the_guest_otp(self):
+		# The OTP lives in the cache, which no rollback restores, so phone validation has to
+		# run before verify_guest_otp deletes it — otherwise one typo costs the guest a code.
+		self.set_event({"allow_guest_booking": 1, "guest_verification_method": "Phone OTP"})
+		otp = send_guest_booking_otp(self.event.name, VALID_PHONE)["otp"]
+		cache_key = f"guest_booking_otp:phone:{VALID_PHONE}"
+		self.addCleanup(frappe.cache.delete_value, cache_key)
+
+		frappe.set_user("Guest")
+		self.addCleanup(frappe.set_user, "Administrator")
+		with self.assertRaises(frappe.ValidationError):
+			process_booking(
+				self.booking_request(
+					guest_email="guest-phone-otp@example.com",
+					guest_full_name="Guest Phone",
+					guest_phone=VALID_PHONE,
+					otp=otp,
+					booking_custom_fields={"contact_number": "+91-12345"},
+				)
+			)
+
+		self.assertTrue(frappe.cache.get_value(cache_key))
+
+	def test_invalid_attendee_level_phone_is_still_refused(self):
+		frappe.db.set_value("Buzz Custom Field", self.phone_field.name, "applied_to", "Ticket")
+		attendees = [
+			{
+				"first_name": "Booker",
+				"email": "booker@example.com",
+				"ticket_type": str(self.free_ticket_type.name),
+				"custom_fields": {"contact_number": "+91-12345"},
+			}
+		]
+		with self.assertRaises(frappe.ValidationError):
+			process_booking(self.booking_request(attendees=attendees))
 
 
 class TestGetBookingDetails(BookingTestCase):

--- a/dashboard/src/components/BookingForm.vue
+++ b/dashboard/src/components/BookingForm.vue
@@ -144,12 +144,12 @@
 								required
 								@blur="prefillAttendee('email')"
 							/>
-							<FormControl
+							<PhoneInput
 								v-if="props.eventDetails.guest_verification_method === 'Phone OTP'"
 								v-model="guestPhone"
-								type="tel"
 								:label="__('Phone Number')"
 								:placeholder="__('Enter your phone number')"
+								:error="guestPhoneError"
 								required
 							/>
 						</div>
@@ -435,6 +435,7 @@ import CustomFieldsSection from "./CustomFieldsSection.vue";
 import EventDetailsHeader from "./EventDetailsHeader.vue";
 import OfflinePaymentDialog from "./OfflinePaymentDialog.vue";
 import PaymentGatewayDialog from "./PaymentGatewayDialog.vue";
+import PhoneInput from "./PhoneInput.vue";
 
 const router = useRouter();
 const route = useRoute();
@@ -557,6 +558,7 @@ const successBookingName = ref("");
 const showOtpModal = ref(false);
 const otpCode = ref("");
 const otpError = ref("");
+const guestPhoneError = ref("");
 const pendingBookingPayload = ref<any>(null);
 const resendCooldown = ref(0);
 let resendCooldownTimer: ReturnType<typeof setInterval> | undefined;
@@ -993,13 +995,24 @@ const sendOtpResource = createResource({
 		);
 	},
 	onError: (error: FrappeError) => {
-		toast.error(error.messages?.[0] || __("Failed to send verification code"));
+		const message = error.messages?.[0] || __("Failed to send verification code");
+		// Under the field, not in a toast the user has to remember while retyping.
+		if (isPhoneOtp.value) {
+			guestPhoneError.value = message;
+			return;
+		}
+		toast.error(message);
 	},
 });
 
 const isPhoneOtp = computed(() => props.eventDetails.guest_verification_method === "Phone OTP");
 
+watch(guestPhone, () => {
+	guestPhoneError.value = "";
+});
+
 function sendOtpForVerification() {
+	guestPhoneError.value = "";
 	sendOtpResource.submit({
 		event: props.eventDetails.name,
 		identifier: isPhoneOtp.value ? guestPhone.value.trim() : guestEmail.value.trim(),

--- a/dashboard/src/components/PhoneInput.vue
+++ b/dashboard/src/components/PhoneInput.vue
@@ -20,12 +20,13 @@
 				:placeholder="placeholder || __('Phone number')"
 			/>
 		</div>
+		<ErrorMessage v-if="error" :message="error" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import { DEFAULT_DIAL_CODE, formatPhone, parsePhone } from "@/utils/phone";
-import { Combobox, TextInput, createResource } from "frappe-ui";
+import { Combobox, ErrorMessage, TextInput, createResource } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 
 interface DialCode {
@@ -38,6 +39,7 @@ const props = defineProps({
 	label: { type: String, default: "Phone" },
 	placeholder: { type: String, default: "" },
 	required: { type: Boolean, default: false },
+	error: { type: String, default: "" },
 });
 
 const emit = defineEmits(["update:modelValue"]);

--- a/e2e/tests/guest-booking.spec.ts
+++ b/e2e/tests/guest-booking.spec.ts
@@ -99,4 +99,25 @@ test.describe("Guest Booking", () => {
 
 		await expect(page.getByText("Booking Confirmed")).toBeVisible({ timeout: 30000 });
 	});
+
+	test("guest phone field rejects a number of the wrong length", async ({ page }) => {
+		const email = `guest-phone-invalid-${uid}@test.com`;
+		const bookingPage = new BookingPage(page);
+		await bookingPage.goto("guest-phone-otp-e2e");
+		await bookingPage.waitForFormLoad();
+
+		await page.locator('input[placeholder="Enter your first name"]').fill("Test");
+		await page.locator('input[placeholder="Enter your last name"]').fill("Guest Phone");
+		await page.locator('input[placeholder="Enter your email"]').fill(email);
+		await page.locator('input[placeholder="Enter your email"]').blur();
+
+		// A well-formed but too-short number passes PhoneInput's digit filter and is
+		// caught by the server, which reports it under the field rather than as a toast.
+		const phoneInput = page.locator('input[placeholder="Enter your phone number"]');
+		await phoneInput.fill("12345");
+		await bookingPage.submit();
+
+		await expect(page.getByText("is not valid")).toBeVisible({ timeout: 10000 });
+		await expect(page.getByText("Verify Your Phone")).toBeHidden();
+	});
 });


### PR DESCRIPTION
Manual backport of #335 to `main`, after the automated backport action failed to cherry-pick.

## Why the action failed

The squashed commit (`23644b7`) touches two unrelated things: the phone-validation fix, and the E2E fixture change that stamps an explicit `team` on every `Buzz Event` / `Event Host`. That second part depends on team-based multi-tenancy (#312), which lives only on `develop` — `main` has no `Buzz Team` doctype and no `ensureTeamMembership` helper.

Cherry-picking the whole commit conflicts in `e2e/tests/auth.setup.ts` and `e2e/tests/check-in.setup.ts`, and the hunks that *do* auto-merge are worse than the conflicts: they quietly introduce `ensureTestTeam`, `team` fields and a call to a helper that does not exist on `main`, so the E2E suite would fail to compile.

## What this PR carries

Only the fix and its tests — the E2E team fixtures are dropped, since there is nothing on `main` for them to bind to:

- `buzz/api/booking/guests.py` — validate the phone branch of `send_booking_otp` with `validate_phone_number_with_country_code`. Validate only, never rewrite, so the OTP cache key stays identical on both the send and verify sides.
- `buzz/api/booking/services.py` — one `validate_phone_fields`, called from `process()` before `build_booking()`, covering booking-level and attendee-level Phone custom fields. Running it early matters: `verify_guest_otp` deletes the code from the cache with no rollback, so validating later cost the guest a valid OTP and left `Attendee Ticket Add-on` rows behind. `verify_guest` also validates the guest phone at submit, covering the direct-API path.
- `dashboard/src/components/BookingForm.vue` — swap the guest phone `FormControl` for the existing `PhoneInput`, and surface OTP-send errors under the field instead of in a toast.
- `dashboard/src/components/PhoneInput.vue` — optional `error` prop rendering frappe-ui's `ErrorMessage`. Existing callers pass nothing and are unchanged.
- `buzz/api/booking/test_booking.py` — `TestSendGuestBookingOtp` and `TestBookingPhoneCustomFields`, unchanged from #335 and free of any team references.
- `e2e/tests/guest-booking.spec.ts` — the too-short-number case, which needs no team.

## Verification

- Cherry-pick conflicts resolved by restoring `main`'s version of `e2e/helpers/frappe.ts` and the six `*.setup.ts` fixtures; the remaining diff is 6 files, +155/−11, and applies with no fuzz.
- `python -m py_compile` clean on the three changed Python files; imports the fix relies on (`validate_phone_number_with_country_code`, `validate_custom_fields`, `watch` in `BookingForm.vue`) all already exist on `main`.
- Test helpers the new cases use (`set_event`, `booking_request`, `free_ticket_type`, the `Additional Field` child doctype) are present on `main`.
- `bench run-tests` and Playwright were not run here — this sandbox has no bench site. CI on this PR is the real check.

Fixes #325 on the `main` line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EePTfzyKVxj7bcpbF9roWx)_