### PR TITLE
feat(dashboard): set page title from event name via usePageMeta

### DIFF
--- a/dashboard/src/components/BaseCustomEventForm.vue
+++ b/dashboard/src/components/BaseCustomEventForm.vue
@@ -157,7 +157,7 @@ import EventDetailsHeader from "@/components/EventDetailsHeader.vue";
 import FormFieldSections from "@/components/FormFieldSections.vue";
 import LoginRequired from "@/components/LoginRequired.vue";
 import type { FrappeError } from "@/types";
-import { Button, Dialog, Spinner, createResource, toast } from "frappe-ui";
+import { Button, Dialog, Spinner, createResource, toast, usePageMeta } from "frappe-ui";
 import { marked } from "marked";
 import { computed, reactive, ref } from "vue";
 import LucideAlertCircle from "~icons/lucide/alert-circle";
@@ -202,6 +202,13 @@ const props = defineProps({
 });
 
 const formData = ref<CustomFormData | null>(null);
+
+usePageMeta(() => {
+	const eventTitle = formData.value?.event?.title;
+	const formTitle = formData.value?.form_title;
+	return eventTitle && formTitle ? { title: `${eventTitle} - ${formTitle}` } : null;
+});
+
 const formValues = reactive<Record<string, any>>({});
 const customFieldValues = ref<Record<string, any>>({});
 const submitted = ref(false);

--- a/dashboard/src/pages/BookTickets.vue
+++ b/dashboard/src/pages/BookTickets.vue
@@ -71,7 +71,7 @@ import type {
 	OfflineMethod,
 } from "@/types";
 import { session } from "@/data/session";
-import { Spinner, createResource } from "frappe-ui";
+import { Spinner, createResource, usePageMeta } from "frappe-ui";
 import { computed, reactive, ref, watch } from "vue";
 import BookingForm from "../components/BookingForm.vue";
 
@@ -104,6 +104,11 @@ const props = defineProps({
 });
 
 const isGuest = computed(() => !session.isLoggedIn);
+
+usePageMeta(() => {
+	const eventTitle = eventBookingData.eventDetails?.title;
+	return eventTitle ? { title: `${eventTitle} - ${__("Register")}` } : null;
+});
 
 const goToHome = () => {
 	window.location.href = "/";

--- a/dashboard/src/pages/EventProposalForm.vue
+++ b/dashboard/src/pages/EventProposalForm.vue
@@ -82,7 +82,7 @@ import CustomFieldInput from "@/components/CustomFieldInput.vue";
 import FormFieldSections from "@/components/FormFieldSections.vue";
 import LoginRequired from "@/components/LoginRequired.vue";
 import type { FrappeError, FrappeField } from "@/types";
-import { Button, Spinner, createResource, toast } from "frappe-ui";
+import { Button, Spinner, createResource, toast, usePageMeta } from "frappe-ui";
 import { marked } from "marked";
 import { computed, reactive, ref } from "vue";
 import LucideAlertCircle from "~icons/lucide/alert-circle";
@@ -100,6 +100,11 @@ const form_values = reactive<Record<string, any>>({});
 const submitted = ref(false);
 const login_required = ref(false);
 const load_error = ref<string | null>(null);
+
+usePageMeta(() => {
+	const bannerTitle = form_data.value?.banner_title;
+	return bannerTitle ? { title: bannerTitle } : null;
+});
 
 const rendered_success_message = computed(() => {
 	const msg = form_data.value?.success_message;

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -147,11 +147,14 @@ router.beforeEach(async (to, from, next) => {
 	next()
 })
 
-router.afterEach(() => {
+const defaultTitle = document.title
+
+router.afterEach((to, from) => {
 	// Pages set their own title via usePageMeta, which never restores it on
 	// unmount. Reset here so a page without one doesn't keep showing the
-	// previous page's title.
-	document.title = "Buzz Dashboard"
+	// previous page's title. Same-path navigation keeps the title: usePageMeta's
+	// watcher won't refire when its data is unchanged, so resetting would stick.
+	if (to.path !== from.path) document.title = defaultTitle
 })
 
 export default router

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -147,4 +147,11 @@ router.beforeEach(async (to, from, next) => {
 	next()
 })
 
+router.afterEach(() => {
+	// Pages set their own title via usePageMeta, which never restores it on
+	// unmount. Reset here so a page without one doesn't keep showing the
+	// previous page's title.
+	document.title = "Buzz Dashboard"
+})
+
 export default router


### PR DESCRIPTION
## Summary
Implement dynamic page title management across the dashboard by leveraging the `usePageMeta` composable from frappe-ui. This ensures each page displays a contextually relevant title in the browser tab and improves the user experience when navigating between pages.

## Key Changes
- **BaseCustomEventForm.vue**: Added `usePageMeta` hook to set page title as `{eventTitle} - {formTitle}` when custom event form data is loaded
- **BookTickets.vue**: Added `usePageMeta` hook to set page title as `{eventTitle} - Register` for ticket booking pages
- **EventProposalForm.vue**: Added `usePageMeta` hook to set page title from the form's `banner_title` field
- **router.ts**: Added `router.afterEach` hook to reset page title to "Buzz Dashboard" after navigation, preventing stale titles from persisting when navigating to pages that don't set their own title

## Implementation Details
- Each page component uses `usePageMeta` to reactively update the document title based on loaded data
- The router's `afterEach` guard provides a fallback mechanism to reset the title, ensuring pages without custom titles don't inherit the previous page's title
- All implementations follow the frappe-ui pattern for page metadata management

https://claude.ai/code/session_01X1xdK1kiaWotaZ5z526Yn9