### PR TITLE
fix(booking): derive add-on prices and validate every selection server-side

### DIFF
--- a/buzz/api/booking/exceptions.py
+++ b/buzz/api/booking/exceptions.py
@@ -24,3 +24,13 @@ class InvalidOTP(BuzzAPIError):
 class RegistrationsClosed(Conflict):
 	title = _lt("Registrations Closed")
 	message = _lt("Registrations for this event are closed")
+
+
+class AddOnNotForEvent(BuzzAPIError):
+	title = _lt("Add-on Unavailable")
+	message = _lt("This add-on is not available for this event.")
+
+
+class InvalidAddOnValue(BuzzAPIError):
+	title = _lt("Invalid Option")
+	message = _lt("{value} is not a valid option for this add-on.")

--- a/buzz/api/booking/services.py
+++ b/buzz/api/booking/services.py
@@ -13,7 +13,7 @@ from frappe.utils import (
 )
 from frappe.utils.password import get_encryption_key
 
-from buzz.api.booking.exceptions import RegistrationsClosed
+from buzz.api.booking.exceptions import AddOnNotForEvent, InvalidAddOnValue, RegistrationsClosed
 from buzz.api.booking.guests import get_or_create_guest_user, verify_guest_otp
 from buzz.api.booking.schemas import (
 	BookingRequest,
@@ -44,6 +44,7 @@ class BookingService:
 	def process(self) -> FreeBookingResponse | OfflineBookingResponse | PaymentLinkResponse:
 		self.validate_event()
 		self.validate_phone_fields()
+		self.validate_add_ons()
 		booking = self.build_booking()
 		booking.insert(ignore_permissions=True)
 		frappe.db.commit()  # nosemgrep: frappe-semgrep-rules.rules.frappe-manual-commit
@@ -66,6 +67,29 @@ class BookingService:
 		validate_custom_fields(self.request.booking_custom_fields or {}, phone_field_map)
 		for attendee in self.request.attendees:
 			validate_custom_fields(attendee.get("custom_fields") or {}, phone_field_map)
+
+	def validate_add_ons(self) -> None:
+		"""Every add-on named in the request must be an enabled add-on of this event, and
+		its value one of the add-on's options. Runs before build_booking so a bad selection
+		is rejected before any document is written."""
+		allowed = self.allowed_add_ons()
+		for attendee in self.request.attendees:
+			for add_on in attendee.get("add_ons") or []:
+				catalog = allowed.get(add_on["add_on"])
+				if not catalog:
+					AddOnNotForEvent.throw()
+				if catalog.user_selects_option:
+					options = (catalog.options or "").split("\n")
+					if add_on.get("value") not in options:
+						InvalidAddOnValue.throw(value=add_on.get("value"))
+
+	def allowed_add_ons(self) -> dict:
+		rows = frappe.db.get_all(
+			"Ticket Add-on",
+			filters={"event": self.request.event, "enabled": 1},
+			fields=["name", "options", "user_selects_option"],
+		)
+		return {row.name: row for row in rows}
 
 	def build_booking(self) -> "EventBooking":
 		booking = frappe.new_doc("Event Booking")
@@ -286,8 +310,13 @@ def validate_custom_fields(custom_fields_data: dict, phone_field_map: dict) -> N
 
 
 def create_add_on_doc(attendee_name: str, add_ons: list[dict]):
+	# Price and currency are read from the catalog and overwrite whatever the request
+	# carried. The Ticket Add-on Value price field only fetches when left empty, so a
+	# price sent in the payload would otherwise be charged as-is.
 	for add_on in add_ons:
-		add_on["currency"] = frappe.db.get_value("Ticket Add-on", add_on["add_on"], "currency")
+		price, currency = frappe.db.get_value("Ticket Add-on", add_on["add_on"], ["price", "currency"])
+		add_on["price"] = price
+		add_on["currency"] = currency
 
 	return frappe.get_doc(
 		{"doctype": "Attendee Ticket Add-on", "add_ons": add_ons, "attendee_name": attendee_name}

--- a/buzz/api/booking/test_booking.py
+++ b/buzz/api/booking/test_booking.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
@@ -8,9 +10,10 @@ from buzz.api.booking import (
 	send_guest_booking_otp,
 	validate_coupon,
 )
-from buzz.api.booking.exceptions import RegistrationsClosed
+from buzz.api.booking.exceptions import AddOnNotForEvent, InvalidAddOnValue, RegistrationsClosed
 from buzz.api.booking.schemas import BookingRequest
 from buzz.api.forms.test_forms import ensure_prompt_named_record
+from buzz.events.doctype.buzz_team.test_buzz_team import create_owned_team, create_user
 
 BOOKER = "booking-owner@example.com"
 OUTSIDER = "booking-outsider@example.com"
@@ -70,10 +73,13 @@ class BookingTestCase(IntegrationTestCase):
 		super().setUpClass()
 		category = ensure_prompt_named_record("Event Category", "Test Booking Category")
 		host = ensure_prompt_named_record("Event Host", "Test Booking Host")
+		owner = create_user("booking-team-owner@example.com", "Booking")
+		cls.team = create_owned_team(f"Booking Test Team {frappe.generate_hash(length=6)}", owner)
 		cls.event = frappe.get_doc(
 			{
 				"doctype": "Buzz Event",
 				"title": f"Booking Test Event {frappe.generate_hash(length=6)}",
+				"team": cls.team,
 				"start_date": "2030-01-01",
 				"end_date": "2030-01-01",
 				"start_time": "10:00:00",
@@ -253,6 +259,145 @@ class TestProcessBooking(BookingTestCase):
 		)
 		self.assertEqual(booking.status, "Approval Pending")
 		self.assertEqual(booking.payment_status, "Verification Pending")
+
+
+class TestBookingAddOnPricing(BookingTestCase):
+	"""The add-on price is server-authoritative: it comes from the Ticket Add-on catalog,
+	never from the booking payload. A guest who names their own price must be ignored."""
+
+	ADD_ON_PRICE = 500
+
+	def setUp(self):
+		super().setUp()
+		self.add_on = frappe.get_doc(
+			{
+				"doctype": "Ticket Add-on",
+				"event": self.event.name,
+				"title": f"Meal {frappe.generate_hash(length=6)}",
+				"price": self.ADD_ON_PRICE,
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+
+	def book_with_add_on(self, add_on_row):
+		attendees = [
+			{
+				"first_name": "Booker",
+				"email": "booker@example.com",
+				"ticket_type": str(self.free_ticket_type.name),
+				"add_ons": [add_on_row],
+			}
+		]
+		# The paid path builds a payment link from a gateway that tests do not configure;
+		# stub it so the booking is created and its stored amounts can be read back.
+		with patch("buzz.api.booking.services.get_payment_link_for_booking", return_value="/pay"):
+			process_booking(self.booking_request(attendees=attendees))
+		return frappe.get_last_doc("Event Booking")
+
+	def test_client_supplied_price_is_ignored(self):
+		# The exploit payload: a Rs 500 add-on booked for Rs 1.
+		booking = self.book_with_add_on({"add_on": self.add_on.name, "value": "Veg", "price": 1})
+		self.assertEqual(booking.attendees[0].add_on_total, self.ADD_ON_PRICE)
+		self.assertEqual(booking.total_amount, self.ADD_ON_PRICE)
+
+	def test_price_is_charged_when_omitted(self):
+		# The legitimate payload carries no price; the catalog price must still be charged.
+		booking = self.book_with_add_on({"add_on": self.add_on.name, "value": "Veg"})
+		self.assertEqual(booking.attendees[0].add_on_total, self.ADD_ON_PRICE)
+
+
+class TestBookingSelectionValidation(BookingTestCase):
+	"""Every selection in the payload must be a legitimate server-side choice for this
+	event. A client cannot name a ticket type or add-on the event never offered."""
+
+	def setUp(self):
+		super().setUp()
+		self.add_on = frappe.get_doc(
+			{
+				"doctype": "Ticket Add-on",
+				"event": self.event.name,
+				"title": f"Meal {frappe.generate_hash(length=6)}",
+				"price": 500,
+				"enabled": 1,
+				"user_selects_option": 1,
+				"options": "Vegetarian meal\nNon-veg",
+			}
+		).insert(ignore_permissions=True)
+
+		foreign_owner = create_user("booking-foreign-owner@example.com", "Foreign")
+		foreign_team = create_owned_team(f"Foreign Team {frappe.generate_hash(length=6)}", foreign_owner)
+		self.foreign_event = frappe.get_doc(
+			{
+				"doctype": "Buzz Event",
+				"title": f"Foreign Event {frappe.generate_hash(length=6)}",
+				"team": foreign_team,
+				"start_date": "2030-01-01",
+				"end_date": "2030-01-01",
+				"start_time": "10:00:00",
+				"end_time": "18:00:00",
+				"medium": "Online",
+				"category": self.event.category,
+				"host": self.event.host,
+				"is_published": 1,
+			}
+		).insert(ignore_permissions=True)
+
+	def attendee(self, **overrides):
+		row = {
+			"first_name": "Booker",
+			"email": "booker@example.com",
+			"ticket_type": str(self.free_ticket_type.name),
+		}
+		row.update(overrides)
+		return row
+
+	def book(self, attendees):
+		# These payloads are rejected in validate, before finalize reaches a payment gateway.
+		process_booking(self.booking_request(attendees=attendees))
+
+	def test_ticket_type_from_another_event_is_refused(self):
+		foreign_ticket_type = frappe.get_doc(
+			{
+				"doctype": "Event Ticket Type",
+				"event": self.foreign_event.name,
+				"title": f"Foreign Ticket {frappe.generate_hash(length=6)}",
+				"price": 0,
+				"is_published": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		with self.assertRaises(frappe.ValidationError):
+			self.book([self.attendee(ticket_type=str(foreign_ticket_type.name))])
+		self.assertIn("not available for this event", frappe.local.message_log[-1]["message"])
+
+	def test_add_on_from_another_event_is_refused(self):
+		foreign_add_on = frappe.get_doc(
+			{
+				"doctype": "Ticket Add-on",
+				"event": self.foreign_event.name,
+				"title": f"Foreign Meal {frappe.generate_hash(length=6)}",
+				"price": 500,
+				"enabled": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		with self.assertRaises(AddOnNotForEvent):
+			self.book([self.attendee(add_ons=[{"add_on": foreign_add_on.name, "value": True}])])
+
+	def test_disabled_add_on_is_refused(self):
+		frappe.db.set_value("Ticket Add-on", self.add_on.name, "enabled", 0)
+		with self.assertRaises(AddOnNotForEvent):
+			self.book([self.attendee(add_ons=[{"add_on": self.add_on.name, "value": "Vegetarian meal"}])])
+
+	def test_invalid_add_on_value_is_refused(self):
+		with self.assertRaises(InvalidAddOnValue):
+			self.book([self.attendee(add_ons=[{"add_on": self.add_on.name, "value": "Gold"}])])
+
+	def test_a_legitimate_selection_is_accepted(self):
+		with patch("buzz.api.booking.services.get_payment_link_for_booking", return_value="/pay"):
+			self.book([self.attendee(add_ons=[{"add_on": self.add_on.name, "value": "Vegetarian meal"}])])
+		booking = frappe.get_last_doc("Event Booking")
+		self.assertEqual(booking.attendees[0].add_on_total, 500)
 
 
 class TestBookingPhoneCustomFields(BookingTestCase):

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -131,6 +131,8 @@ class EventBooking(Document):
 
 		for ticket_type, num_tickets in num_tickets_by_type.items():
 			ticket_type_doc = frappe.get_cached_doc("Event Ticket Type", ticket_type)
+			if str(ticket_type_doc.event) != str(self.event):
+				frappe.throw(_("{0} is not available for this event").format(ticket_type_doc.title))
 			if not ticket_type_doc.is_published:
 				frappe.throw(frappe._(f"{ticket_type_doc.title} tickets no longer available!"))
 


### PR DESCRIPTION
## What

`process_booking` is guest-reachable and trusted several payload fields it should have derived or checked. A guest set an add-on's `price` in the request and booked a paid add-on for Re 1 — the `Ticket Add-on Value.price` field only `fetch_if_empty`, so a supplied price stood while `create_add_on_doc` overwrote only the currency. That, plus two neighbouring gaps, is fixed here.

- **Add-on price/currency** now come from the catalog, ignoring whatever the request sent.
- **Ticket type** is scoped to the booked event in `validate_ticket_availability` (the shared function the API *and* Desk route through) — a published type from another event was previously accepted at its own price.
- **Add-ons** are validated against the event catalog before any write: cross-event, disabled, or a `value` not in the add-on's options are rejected (`AddOnNotForEvent` / `InvalidAddOnValue`). Options were enforced in client JS only.

## Not changing

- No dashboard change — the form already sends only catalog add-on names and valid options, never a price.
- Coupon and offline-method paths were already event-scoped.
- Add-on scoping lives in the API service (guest path); ticket-type scoping is in the controller so Desk is covered too. Desk-created add-ons stay trusted — `Attendee Ticket Add-on` carries no event to key on.

## Out of scope

Identity/input hardening flagged in the audit but deferred: attendee email format, `payment_proof` URL, `payment_gateway` validation, and free-text length bounds.

## Testing

- `bench --site buzz.localhost run-tests --module buzz.api.booking.test_booking --skip-before-tests` → 33 passed. Each new test is red on `develop` (selection accepted) and green with its guard.
- E2E: replayed the original guest attack (free ticket + Rs 500 add-on, payload `price:1`). Booking persisted at `total_amount=500`, draft, no ticket issued — the Re 1 booking is gone. A bad option (`value:"Gold"`) is rejected `400 InvalidAddOnValue` before any row is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)